### PR TITLE
Install django-silk for API profiling

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,10 +1,14 @@
 asgiref==3.8.1
+autopep8==2.3.2
 Django==5.1.4
 django-cors-headers==4.6.0
 django-filter==24.3
+django-silk==5.3.2
 djangorestframework==3.15.2
 djangorestframework-gis==1.1
+gprof2dot==2024.6.6
 psycopg==3.2.3
+pycodestyle==2.12.1
 sqlparse==0.5.3
 typing_extensions==4.12.2
 tzdata==2024.2

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -43,11 +43,13 @@ INSTALLED_APPS = [
     'rest_framework_gis',
     'server.watershed',
     'corsheaders',
+    'silk',
 ]
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'silk.middleware.SilkyMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/watershed/', include('server.watershed.urls')),
+    path('silk/', include('silk.urls', namespace='silk')),
 ]


### PR DESCRIPTION
Add django-silk for basic API analytics - after experimenting with the different profiling options, I see it sufficient to use the information silk provides out of the box for now. More fine-grain profiling can be implemented if needed.