### PR TITLE
Api documentation

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.8.1
+attrs==25.1.0
 autopep8==2.3.2
 Django==5.1.4
 django-cors-headers==4.6.0
@@ -6,9 +7,17 @@ django-filter==24.3
 django-silk==5.3.2
 djangorestframework==3.15.2
 djangorestframework-gis==1.1
+drf-spectacular==0.28.0
 gprof2dot==2024.6.6
+inflection==0.5.1
+jsonschema==4.23.0
+jsonschema-specifications==2024.10.1
 psycopg==3.2.3
 pycodestyle==2.12.1
+PyYAML==6.0.2
+referencing==0.36.2
+rpds-py==0.22.3
 sqlparse==0.5.3
 typing_extensions==4.12.2
 tzdata==2024.2
+uritemplate==4.1.1

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'server.watershed',
     'corsheaders',
     'silk',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -140,3 +141,14 @@ CORS_ALLOWED_ORIGINS = [
     'http://localhost:5173', # Vite development server
     'http://127.0.0.1:5173',
 ]
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Utility Watershed Analytics API',
+    'DESCRIPTION': 'Backend DRF API for a full-stack web app providing water utility management with interactive geospatial insights and analytics for informed decision-making in water resource management.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -16,9 +16,20 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    # Watershed app
     path('api/watershed/', include('server.watershed.urls')),
+
+    # Admin
+    path('admin/', admin.site.urls),
+
+    # API profiling
     path('silk/', include('silk.urls', namespace='silk')),
+
+    # API documentation
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/server/server/watershed/serializers.py
+++ b/server/server/watershed/serializers.py
@@ -4,13 +4,7 @@ from rest_framework import serializers
 
 class WatershedBorderSerializer(GeoFeatureModelSerializer):
     """
-    Full serializer with all watershed border fields.
-    Uses specialized GeoFeatureModelSerializer to serialize model data
-    into GeoJSON.
-    Attributes:
-        model (WatershedBorder): The model class being serialized
-        geo_field (str): Name of the geometry field ('geom')
-        fields (str): Specifies all model fields should be included ('__all__')
+    Serializes the WatershedBorder model with all of its fields.
     """
     class Meta:
         model = WatershedBorder
@@ -19,7 +13,8 @@ class WatershedBorderSerializer(GeoFeatureModelSerializer):
 
 class WatershedBorderBasicSerializer(GeoFeatureModelSerializer):
     """
-    Basic serializer with only essential fields and a hyperlink to full details
+    Serializes a simplified version of the WatershedBorder model,
+    including essential fields and a hyperlink to full details.
     """
     details_url = serializers.HyperlinkedIdentityField(
         view_name='watershedborder-detail',
@@ -30,3 +25,4 @@ class WatershedBorderBasicSerializer(GeoFeatureModelSerializer):
         model = WatershedBorder
         geo_field = 'geom'
         fields = ('id', 'geom', 'pws_name', 'city', 'cnty_name', 'acres', 'details_url')
+        description = "Basic serializer for Watershed Border with limited fields and a details URL."

--- a/server/server/watershed/views.py
+++ b/server/server/watershed/views.py
@@ -1,23 +1,42 @@
 from rest_framework import viewsets
 from .models import WatershedBorder
 from .serializers import WatershedBorderSerializer, WatershedBorderBasicSerializer
+from drf_spectacular.utils import extend_schema
 
+@extend_schema(
+    description="""
+**Retrieve comprehensive watershed border data.**  
+
+- Provides **full details** for each watershed border  
+- Best used when selecting an **individual watershed**  
+
+Due to the detailed nature of this API, it is **not recommended** for retrieving large datasets at once.
+    """
+)
 class WatershedBorderViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    This ViewSet provides read-only access to WatershedBorder model instances,
-    allowing only GET requests to list all watershed borders or retrieve specific ones.
-    Attributes:
-        queryset: QuerySet of all WatershedBorder objects
-        serializer_class: Serializer class to convert WatershedBorder objects to/from JSON
+    This ViewSet provides read-only access to WatershedBorder model instances.
+
+    Note that the payload served by this view can be large and thus, requesting multiple WatershedBorder
+    model instances is not advised.
     """
     queryset = WatershedBorder.objects.all()
     serializer_class = WatershedBorderSerializer
 
+@extend_schema(
+    description="""
+**Retrieve simplified watershed border data.**  
+
+- Provides **only essential** information for each watershed border  
+- Best used when **retrieving multiple watershed borders** for visualization
+    """
+)
 class WatershedBorderBasicViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    This ViewSet provides a simplified read-only view of WatershedBorder model instances,
-    returning only basic fields. Like its parent class, it allows only GET requests to 
-    list all watershed borders or retrieve specific ones.
+    This ViewSet provides read-only access to simplified BasicWatershedBorder model instances.
+    
+    This endpoint is intended for scenarios where an overview of multiple watershed borders is required, 
+    particularly for mapping purposes where detailed geometry isn't necessary.
     """
     queryset = WatershedBorder.objects.all()
     serializer_class = WatershedBorderBasicSerializer


### PR DESCRIPTION
Install and setup drf-spectacular for the Django backend to generate API schema documentation following OpenAPI 3.0 standards. 

Below are screenshots of the swagger and rebloc UI:
![Screenshot from 2025-02-03 01-50-19](https://github.com/user-attachments/assets/0b05fbed-4c73-437e-ba36-8aa5133019cd)
![image](https://github.com/user-attachments/assets/e8171102-0b0c-4390-9883-8f7f6085a29b)

