### PR TITLE
Optimize watershedborder API

### DIFF
--- a/server/server/watershed/load.py
+++ b/server/server/watershed/load.py
@@ -67,6 +67,6 @@ def run(verbose=True):
     with connection.cursor() as cursor:
         cursor.execute("""
             UPDATE watershed_watershedborder
-            SET simplified_geom = ST_SimplifyPreserveTopology(geom, 0.01)
+            SET simplified_geom = ST_SimplifyPreserveTopology(geom, 0.02)
             WHERE geom IS NOT NULL;
         """)

--- a/server/server/watershed/serializers.py
+++ b/server/server/watershed/serializers.py
@@ -9,7 +9,7 @@ class WatershedBorderSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = WatershedBorder
         geo_field = 'geom'
-        fields = '__all__'
+        exclude = ('simplified_geom',)
 
 class WatershedBorderBasicSerializer(GeoFeatureModelSerializer):
     """
@@ -23,6 +23,6 @@ class WatershedBorderBasicSerializer(GeoFeatureModelSerializer):
 
     class Meta:
         model = WatershedBorder
-        geo_field = 'geom'
-        fields = ('id', 'geom', 'pws_name', 'city', 'cnty_name', 'acres', 'details_url')
+        geo_field = 'simplified_geom'
+        fields = ('id', 'simplified_geom', 'pws_name', 'city', 'cnty_name', 'acres', 'details_url')
         description = "Basic serializer for Watershed Border with limited fields and a details URL."

--- a/server/server/watershed/views.py
+++ b/server/server/watershed/views.py
@@ -20,7 +20,7 @@ class WatershedBorderViewSet(viewsets.ReadOnlyModelViewSet):
     Note that the payload served by this view can be large and thus, requesting multiple WatershedBorder
     model instances is not advised.
     """
-    queryset = WatershedBorder.objects.all()
+    queryset = WatershedBorder.objects.defer('simplified_geom')
     serializer_class = WatershedBorderSerializer
 
 @extend_schema(
@@ -38,5 +38,5 @@ class WatershedBorderBasicViewSet(viewsets.ReadOnlyModelViewSet):
     This endpoint is intended for scenarios where an overview of multiple watershed borders is required, 
     particularly for mapping purposes where detailed geometry isn't necessary.
     """
-    queryset = WatershedBorder.objects.all()
+    queryset = WatershedBorder.objects.only("id", "simplified_geom", "pws_name", "city", "cnty_name", "acres")
     serializer_class = WatershedBorderBasicSerializer


### PR DESCRIPTION
* Increase geometry simplification threshold from 0.01 to 0.02
* Optimize queryset retrieval in views to load only necessary fields
* Update serializers accordingly

> **Note**: The geometry simplification should be discussed with the client to decide on an agreeable threshold. 

Performance was gauged by triggering the request through the frontend and measuring the average request time and database time over 20 requests. The performance improved from **4682 ms request time** and **240ms DB time** to **190 ms request time** and **21 ms DB time**.