### PR TITLE
Fix channels rendering below when subcatchments are toggled.

### DIFF
--- a/client/src/components/map/Map.tsx
+++ b/client/src/components/map/Map.tsx
@@ -262,6 +262,7 @@ export default function Map(): JSX.Element {
           <GeoJSON
             data={memoChannels}
             style={channelStyle}
+            pane="markerPane"
           />
         )}
       </MapContainer>


### PR DESCRIPTION
This PR fixes channels rendering below watersheds when subcatchments were toggled on and off and closes issue #65.