### PR TITLE
Implement external link to uncalibrated wepp results.

### DIFF
--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -48,6 +48,7 @@ const useStyles = tss.create(({ theme }) => ({
         padding: `${theme.spacing(1.5)} ${theme.spacing(2)}`,
         justifyContent: 'flex-start',
         fontSize: theme.typography.body2.fontSize,
+        textTransform: 'none',
         '&:hover': {
             borderColor: theme.palette.accent.main,
         },
@@ -175,11 +176,18 @@ export default function WatershedOverview() {
                 <div className={classes.accordionGroup} key={watershedID}>
                     <Button
                         className={classes.actionButton}
-                        aria-label='View Calibrated WEPP Results'
-                        title='View Calibrated WEPP Results'
+                        aria-label='View Uncalibrated WEPP Results'
+                        title='View Uncalibrated WEPP Results'
                         variant="text"
+                        onClick={() =>
+                            window.open(
+                                `https://wepp.cloud/weppcloud/runs/${watershedID}/disturbed9002_wbt/`,
+                                '_blank',
+                                'noopener,noreferrer'
+                            )
+                        }
                     >
-                        View Calibrated WEPP Results
+                        View Uncalibrated WEPP Results
                     </Button>
 
                     <Button


### PR DESCRIPTION
This pull request implements the view uncalibrated wepp results external link and closes #78.

# **Notes**
- The link currently doesn't work as our data is mismatches with Rogers recent data updates that can be found [here](https://wepp.cloud/weppcloud/batch/nasa-roses-2026-sbs/browse/) and [here](https://wepp.cloud/weppcloud/batch/nasa-roses-2026-sbs/browse/resources/nasa-roses-2026-sbs_completed.geojson)
- This eventually needs to be toggled between viewing uncalibrated and calibrated wepp results but since we don't have that data currently all watersheds will link to the uncalibrated wepp results view in the gl deck