### PR TITLE
Change map center value.

### DIFF
--- a/client/src/components/map/Map.tsx
+++ b/client/src/components/map/Map.tsx
@@ -48,8 +48,8 @@ const useStyles = tss.create(({ theme }) => ({
 
 // Center coordinates [lat, lng]
 const CENTER: [number, number] = [
-  Number(((43.88 + 49.19) / 2).toFixed(2)),
-  Number(((-124.52 + -116.93) / 2).toFixed(2))
+  Number(((43.75 + 49.19) / 2).toFixed(2)),
+  Number(((-124.52 + -113.93) / 2).toFixed(2))
 ];
 
 // Bounds


### PR DESCRIPTION
This pull request makes a small adjustment to the map center coordinates in the `Map.tsx` component, slightly updating the latitude and longitude values to better reflect the desired map center.

- Updated the `CENTER` constant in `Map.tsx` by changing the latitude from 43.88 to 43.75 and the longitude from -116.93 to -113.93.