### PR TITLE
fix: update colormap documentation and correct tile URL for 4-class SBS raster

### DIFF
--- a/server/server/watershed/sbs_raster/color_map.py
+++ b/server/server/watershed/sbs_raster/color_map.py
@@ -2,7 +2,7 @@
 SBS (Soil Burn Severity) raster colormaps.
 
 Class definitions sourced from:
-  https://github.com/rogerlew/wepppy/blob/master/wepppy/nodb/mods/baer/README.sbs_map.md
+  https://github.com/rogerlew/wepppy/blob/master/wepppy/nodb/mods/baer/README.sbs_map.md#color-tables-and-palette-contracts
 
 The **backend is the source of truth** for all SBS colormaps.
 tile.py uses get_render_colormap() to render PNG tiles server-side; the frontend

--- a/server/server/watershed/sbs_raster/tests.py
+++ b/server/server/watershed/sbs_raster/tests.py
@@ -439,7 +439,7 @@ class SbsRasterTileViewTests(APITestCase):
         tif_url_arg = mock_tile.call_args[0][0]
         expected = (
             f'https://wepp.cloud/weppcloud/runs/{self.watershed.runid}'
-            '/disturbed_wbt/download/disturbed/prediction_wgs84_merged.wgs.tif'
+            '/disturbed_wbt/download/disturbed/sbs_4class.tif'
         )
         self.assertEqual(tif_url_arg, expected)
 

--- a/server/server/watershed/sbs_raster/views.py
+++ b/server/server/watershed/sbs_raster/views.py
@@ -86,7 +86,7 @@ class SbsRasterTileView(APIView):
 
         config = get_config()
         base = config.api.weppcloud_base_url.rstrip('/')
-        tif_url = f"{base}/runs/{runid}/disturbed_wbt/download/disturbed/prediction_wgs84_merged.wgs.tif"
+        tif_url = f"{base}/runs/{runid}/disturbed_wbt/download/disturbed/sbs_4class.tif"
 
         try:
             png_bytes = get_tile_png(tif_url, z, x, y, mode)


### PR DESCRIPTION
This pull request updates the Soil Burn Severity (SBS) raster tile rendering logic to use a new TIFF file source with 4 classes for generating PNG tiles. The change affects both the application logic and its corresponding tests.

**File source update:**

* Updated the TIFF file path used for SBS raster tile rendering from `prediction_wgs84_merged.wgs.tif` to `sbs_4class.tif` in both the view logic (`sbs_raster/views.py`) and the related test (`sbs_raster/tests.py`). [[1]](diffhunk://#diff-24a728758a859017613f515f2d5da256a6a5dbf9b9121acd492c954aa4a685a5L89-R89) [[2]](diffhunk://#diff-1b1f520ac7d9075adf7c3b41253320ae5ea618f0ff9a2d672f6ea286f600ad5dL442-R442)

**Documentation update:**

* Clarified the documentation link in `color_map.py` to point to the specific section about color tables and palette contracts.…BS raster