### PR TITLE
Implement bottom panel visibility toggle

### DIFF
--- a/client/src/components/bottom-panels/BottomPanel.tsx
+++ b/client/src/components/bottom-panels/BottomPanel.tsx
@@ -4,6 +4,9 @@ import DragHandleIcon from "@mui/icons-material/DragHandle";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 
+const MIN_HEIGHT_PX = 24;
+const MAX_HEIGHT_PX = 450;
+
 type BottomPanelProps = {
   isOpen: boolean;
   children: React.ReactNode;
@@ -15,7 +18,7 @@ const useStyles = tss.create(({ theme }) => ({
     left: 0,
     right: 0,
     bottom: 0,
-    maxHeight: "450px",
+    maxHeight: `${MAX_HEIGHT_PX}px`,
     background: theme.palette.background.default,
     color: theme.palette.primary.contrastText,
     borderTop: `0.5px solid ${theme.palette.primary.dark}`,
@@ -43,7 +46,7 @@ const useStyles = tss.create(({ theme }) => ({
   },
   bottomPanelDrag: {
     flex: 1,
-    height: "24px",
+    height: `${MIN_HEIGHT_PX}px`,
     cursor: "ns-resize",
     display: "flex",
     alignItems: "center",
@@ -63,26 +66,34 @@ export default function BottomPanel({ isOpen, children }: BottomPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const startY = useRef<number>(0);
   const startHeight = useRef<number>(0);
+  const dragHeight = useRef<number>(0);
 
   const handleDrag = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!isExpanded) setIsExpanded(true);
     startY.current = e.clientY;
-    startHeight.current = panelRef.current?.offsetHeight || 24;
+    startHeight.current = panelRef.current?.offsetHeight || MIN_HEIGHT_PX;
     document.addEventListener("mousemove", onDrag);
     document.addEventListener("mouseup", stopDrag);
   };
 
   const onDrag = (e: MouseEvent) => {
     if (panelRef.current) {
-      const newHeight = startHeight.current - (e.clientY - startY.current);
-      panelRef.current.style.height = `${Math.max(24, Math.min(450, newHeight))}px`;
+      const newHeight = Math.max(
+        MIN_HEIGHT_PX,
+        Math.min(
+          MAX_HEIGHT_PX,
+          startHeight.current - (e.clientY - startY.current),
+        ),
+      );
+      dragHeight.current = newHeight;
+      panelRef.current.style.height = `${newHeight}px`;
     }
   };
 
   const stopDrag = () => {
     document.removeEventListener("mousemove", onDrag);
     document.removeEventListener("mouseup", stopDrag);
-    if (panelRef.current && panelRef.current.offsetHeight <= 24) {
+    if (dragHeight.current <= MIN_HEIGHT_PX) {
       setIsExpanded(false);
     }
   };
@@ -104,10 +115,13 @@ export default function BottomPanel({ isOpen, children }: BottomPanelProps) {
           <DragHandleIcon data-testid="drag-handle-icon" />
         </div>
         <button
+          type="button"
           className={classes.notch}
           onClick={() => {
             if (panelRef.current) {
-              panelRef.current.style.height = isExpanded ? "24px" : "";
+              panelRef.current.style.height = isExpanded
+                ? `${MIN_HEIGHT_PX}px`
+                : "";
             }
             setIsExpanded((prev) => !prev);
           }}
@@ -127,7 +141,13 @@ export default function BottomPanel({ isOpen, children }: BottomPanelProps) {
           )}
         </button>
       </div>
-      <div className={classes.bottomPanelContent}>{children}</div>
+      <div
+        className={classes.bottomPanelContent}
+        hidden={!isExpanded}
+        aria-hidden={!isExpanded}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/client/src/components/map/WatershedMap.tsx
+++ b/client/src/components/map/WatershedMap.tsx
@@ -283,13 +283,13 @@ export default function WatershedMap(): JSX.Element {
           choroplethLoading ||
           landuseLoading ||
           scenarioLoading) && (
-            <div
-              className={classes.mapLoadingOverlay}
-              data-testid="map-loading-overlay"
-            >
-              <CircularProgress size={50} color="inherit" />
-            </div>
-          )}
+          <div
+            className={classes.mapLoadingOverlay}
+            data-testid="map-loading-overlay"
+          >
+            <CircularProgress size={50} color="inherit" />
+          </div>
+        )}
 
         <TileLayer
           key={selectedLayerId}

--- a/client/src/tests/BottomPanel.test.tsx
+++ b/client/src/tests/BottomPanel.test.tsx
@@ -293,4 +293,138 @@ describe("BottomPanel", () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe("toggle functionality", () => {
+    it("renders the toggle button with collapse label by default", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute("aria-label", "Collapse panel");
+      expect(screen.getByTestId("chevron-down-icon")).toBeInTheDocument();
+    });
+
+    it("collapses content and shows expand icon when toggle is clicked", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      fireEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-label", "Expand panel");
+      expect(screen.getByTestId("chevron-up-icon")).toBeInTheDocument();
+
+      const content = screen.getByText("Content").closest("[hidden]");
+      expect(content).not.toBeNull();
+    });
+
+    it("expands content when toggle is clicked again after collapsing", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      fireEvent.click(toggle);
+      fireEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-label", "Collapse panel");
+      expect(screen.getByTestId("chevron-down-icon")).toBeInTheDocument();
+      expect(screen.getByText("Content")).toBeVisible();
+    });
+
+    it("sets panel height to min when collapsing via toggle", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const panel = screen.getByTestId("bottom-panel") as HTMLDivElement;
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      fireEvent.click(toggle);
+
+      expect(panel.style.height).toBe("24px");
+    });
+
+    it("clears inline height when expanding via toggle", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const panel = screen.getByTestId("bottom-panel") as HTMLDivElement;
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      fireEvent.click(toggle);
+      fireEvent.click(toggle);
+
+      expect(panel.style.height).toBe("");
+    });
+
+    it("auto-collapses when dragged to minimum height", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const panel = screen.getByTestId("bottom-panel") as HTMLDivElement;
+      const dragHandle = screen.getByTestId("bottom-panel-drag");
+
+      Object.defineProperty(panel, "offsetHeight", {
+        value: 100,
+        configurable: true,
+      });
+
+      fireEvent.mouseDown(dragHandle, { clientY: 500 });
+      fireEvent.mouseMove(document, { clientY: 700 });
+      fireEvent.mouseUp(document);
+
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      expect(toggle).toHaveAttribute("aria-label", "Expand panel");
+      expect(screen.getByTestId("chevron-up-icon")).toBeInTheDocument();
+    });
+
+    it("auto-expands when dragging from collapsed state", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      fireEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-label", "Expand panel");
+
+      const dragHandle = screen.getByTestId("bottom-panel-drag");
+      fireEvent.mouseDown(dragHandle, { clientY: 500 });
+
+      expect(toggle).toHaveAttribute("aria-label", "Collapse panel");
+    });
+
+    it("hides content from screen readers when collapsed", () => {
+      render(
+        <BottomPanel isOpen={true}>
+          <div>Content</div>
+        </BottomPanel>,
+      );
+
+      const toggle = screen.getByTestId("bottom-panel-toggle");
+      fireEvent.click(toggle);
+
+      const contentWrapper = screen.getByText("Content").parentElement;
+      expect(contentWrapper).toHaveAttribute("aria-hidden", "true");
+      expect(contentWrapper).toHaveAttribute("hidden");
+    });
+  });
 });


### PR DESCRIPTION
This pull request updates the `BottomPanel` component to improve its usability and user interface by adding a collapse/expand toggle and refining the drag-to-resize functionality. The changes enhance the panel's accessibility and make its behavior more intuitive.

**UI/UX Improvements:**

* Added a collapse/expand toggle button to the top bar, allowing users to quickly minimize or restore the panel. The button switches between `KeyboardArrowDownIcon` and `KeyboardArrowUpIcon` depending on the panel state.
* Introduced a new `isExpanded` state to control the panel's expanded/collapsed status and synchronize it with both drag and button interactions.
* Updated the drag-to-resize logic so that dragging the panel to its minimum height automatically collapses it, and initiating a drag while collapsed expands it.

**Styling and Layout Adjustments:**

* Refined styles for the top bar and toggle button, improving alignment, appearance, and accessibility. Added new style classes `topBar` and `notch`, and updated existing ones for better layout.
* Increased the minimum panel height from 16px to 24px and adjusted related style and logic to match the new minimum size. [[1]](diffhunk://#diff-148fa5e0950dafae349d15227d7638cb0e114d60cb4dd23b3f9534976302baa3L16-L29) [[2]](diffhunk://#diff-148fa5e0950dafae349d15227d7638cb0e114d60cb4dd23b3f9534976302baa3R61-R87)

**Screenshot:**
<img width="1346" height="448" alt="image" src="https://github.com/user-attachments/assets/2ff8545c-3acf-417c-a762-816932cd2fce" />
