### PR TITLE
Update Caddyfile to include firewisewatersheds.org domain

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,7 +2,7 @@
     email brandon.xu@wsu.edu
 }
 
-unstable.wepp.cloud {
+firewisewatersheds.org, unstable.wepp.cloud {
     root * /app/client/build
 
     route {


### PR DESCRIPTION
This pull request updates the `Caddyfile` to expand the domain configuration for the web server. The main change is adding support for the `firewisewatersheds.org` domain alongside the existing `unstable.wepp.cloud` domain.

Domain configuration update:

* Added `firewisewatersheds.org` to the list of domains served by the same configuration as `unstable.wepp.cloud` in the `Caddyfile`.