### PR TITLE
Implement deval details external link.

### DIFF
--- a/client/src/api/apiEndpoints.ts
+++ b/client/src/api/apiEndpoints.ts
@@ -66,6 +66,9 @@ export const API_ENDPOINTS = {
       DEFAULT_WEPP_DASHBOARD_RUN_BASE;
     return `${WEPPCLOUD_BASE}/${e(runId)}/${runBase}/gl-dashboard`;
   },
+  // WEPPcloud deval details report for a given watershed run.
+  WEPP_DEVAL_DETAILS: (runId: string) =>
+    `${WEPPCLOUD_BASE}/${e(runId)}/disturbed9002_wbt/report/deval_details/`,
   // Direct download link for the SBS 4-class classified GeoTIFF.
   // Uses the same disturbed sub-run base as WEPP_DASHBOARD.
   SBS_TIFF_DOWNLOAD: (runId: string) => {

--- a/client/src/components/map/controls/Layers.tsx
+++ b/client/src/components/map/controls/Layers.tsx
@@ -51,7 +51,7 @@ const useStyles = tss.create(({ theme }) => ({
     padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
     borderRadius: theme.spacing(1),
     boxShadow: "0 2px 10px rgba(0, 0, 0, 0.5)",
-    zIndex: 1000,
+    zIndex: 9999,
   },
   layersHeading: {
     marginBottom: theme.spacing(1),

--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -70,11 +70,12 @@ const useStyles = tss.create(({ theme }) => ({
   },
   actionLink: {
     fontSize: theme.typography.body2.fontSize,
-    color: theme.palette.accent.main,
+    color: theme.palette.accent.light,
     textAlign: "left",
     cursor: "pointer",
     display: "block",
     marginBottom: theme.spacing(1.5),
+    textDecorationColor: theme.palette.accent.light,
   },
   skeletonClose: {
     marginTop: theme.spacing(1.5),
@@ -342,10 +343,20 @@ export default function WatershedOverview() {
             target="_blank"
             rel="noopener noreferrer"
             className={classes.actionLink}
-            underline="hover"
+            underline="always"
             aria-label="View Detailed WEPP Model Results"
           >
             View Detailed WEPP Model Results
+          </Link>
+          <Link
+            href={runId ? API_ENDPOINTS.WEPP_DEVAL_DETAILS(runId) : undefined}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={classes.actionLink}
+            underline="always"
+            aria-label="View WEPP Deval Details Report"
+          >
+            View WEPP Deval Details Report
           </Link>
           <WeppSection />
         </Paper>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -137,7 +137,7 @@ a:not([class]) {
 /* Make images easier to work with */
 img,
 picture,
-svg {
+svg:not([class]) {
   max-width: 100%;
   display: block;
 }


### PR DESCRIPTION
This pull request adds a new link to the Watershed Overview panel for accessing the WEPP Deval Details Report, and updates the appearance of action links for consistency. The main changes include introducing a new API endpoint, updating link styling, and adding the new report link to the user interface.

**User Interface Enhancements:**

* Added a new "View WEPP Deval Details Report" link to the `WatershedOverview` side panel, allowing users to access the detailed WEPP Deval report for a given watershed run.
* Changed the "View Detailed WEPP Model Results" link to always show an underline for better visibility and consistency.
* Updated the `actionLink` style to use `theme.palette.accent.light` for color and text decoration, improving visual consistency with the application's theme.

**API Endpoint Updates:**

* Added a new `WEPP_DEVAL_DETAILS` endpoint to `API_ENDPOINTS` in `apiEndpoints.ts` for generating the correct URL to the Deval Details report.