### PR TITLE
Overhaul Search control with ranked results and improved navigation

### DIFF
--- a/client/src/components/bottom-panels/ScenariosTable.tsx
+++ b/client/src/components/bottom-panels/ScenariosTable.tsx
@@ -35,8 +35,8 @@ const useStyles = tss.create(({ theme }) => ({
 
 type MetricKey = {
   [K in keyof ScenarioSummaryRow]: ScenarioSummaryRow[K] extends number | null
-  ? K
-  : never;
+    ? K
+    : never;
 }[keyof ScenarioSummaryRow];
 
 type MetricColumn = {

--- a/client/src/components/map/WatershedMap.tsx
+++ b/client/src/components/map/WatershedMap.tsx
@@ -285,9 +285,9 @@ export default function WatershedMap(): JSX.Element {
       className={cx(
         classes.mapContainer,
         runId &&
-        !rhessysSpatialEffective &&
-        (!rhessysOutputsEffective || rhessysChoroplethActive) &&
-        classes.mapContainerWithPanel,
+          !rhessysSpatialEffective &&
+          (!rhessysOutputsEffective || rhessysChoroplethActive) &&
+          classes.mapContainerWithPanel,
       )}
     >
       <MapContainer
@@ -308,13 +308,13 @@ export default function WatershedMap(): JSX.Element {
           landuseLoading ||
           scenarioLoading ||
           rhessysChoroplethLoading) && (
-            <div
-              className={classes.mapLoadingOverlay}
-              data-testid="map-loading-overlay"
-            >
-              <CircularProgress size={50} color="inherit" />
-            </div>
-          )}
+          <div
+            className={classes.mapLoadingOverlay}
+            data-testid="map-loading-overlay"
+          >
+            <CircularProgress size={50} color="inherit" />
+          </div>
+        )}
 
         <TileLayer
           key={selectedLayerId}

--- a/client/src/components/map/WatershedMap.tsx
+++ b/client/src/components/map/WatershedMap.tsx
@@ -330,7 +330,7 @@ export default function WatershedMap(): JSX.Element {
 
         {/* TOP RIGHT CONTROLS */}
         <div className="leaflet-top leaflet-right">
-          <SearchControl />
+          <SearchControl watersheds={watersheds} />
           <LayersControl
             selectedLayerId={selectedLayerId}
             setSelectedLayerId={setSelectedLayerId}

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -497,7 +497,13 @@ export default function SearchControl({ watersheds }: SearchControlProps) {
     const matches = rankWatershedMatches(normalizedQuery, searchIndex);
     if (matches.length === 0) {
       setResults([]);
-      toast.error("No watershed match found. Try coordinates or another name.");
+      const hasSearchableWatersheds =
+        Boolean(watersheds?.features?.length) && searchIndex.length > 0;
+      toast.error(
+        hasSearchableWatersheds
+          ? "No watershed match found. Try coordinates or another name."
+          : "Watershed data is still loading or unavailable. Try coordinates.",
+      );
       return;
     }
 

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -208,6 +208,20 @@ function collectLngLatPairs(value: unknown, pairs: [number, number][]): void {
   }
 }
 
+function collectGeometryPairs(
+  geometry: GeoJSON.Geometry,
+  pairs: [number, number][],
+): void {
+  if (geometry.type === "GeometryCollection") {
+    for (const child of geometry.geometries) {
+      collectGeometryPairs(child, pairs);
+    }
+    return;
+  }
+
+  collectLngLatPairs(geometry.coordinates, pairs);
+}
+
 function getBoundsFromGeometry(
   geometry: GeoJSON.Geometry | null | undefined,
 ): [number, number, number, number] | null {
@@ -216,7 +230,7 @@ function getBoundsFromGeometry(
   }
 
   const pairs: [number, number][] = [];
-  collectLngLatPairs((geometry as GeoJSON.Geometry).coordinates, pairs);
+  collectGeometryPairs(geometry, pairs);
 
   if (pairs.length === 0) {
     return null;
@@ -255,16 +269,18 @@ function toSearchIndex(
       const center: [number, number] = [(south + north) / 2, (west + east) / 2];
       const props = feature.properties;
 
-      return {
+      const item: WatershedIndexItem = {
         id: String(feature.id ?? props.pws_id ?? ""),
         name: props.pws_name ?? props.huc10_name ?? "Unknown Watershed",
         sourceName: props.srcname ?? "",
         huc: props.huc10_id ?? "",
         center,
         bbox,
-      } satisfies WatershedIndexItem;
+      };
+
+      return item.id ? item : null;
     })
-    .filter((item): item is WatershedIndexItem => item !== null && !!item.id);
+    .filter((item): item is WatershedIndexItem => item !== null);
 }
 
 const useStyles = tss.create(({ theme }) => ({

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -489,7 +489,7 @@ export default function SearchControl({ watersheds }: SearchControlProps) {
 
     if (isCoordinateLike(trimmedInput)) {
       toast.error(
-        'Invalid coordinates. Please enter in "latitude, longitude" format.',
+        'Invalid coordinates. Use "latitude, longitude" or "latitude longitude".',
       );
       return;
     }

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -110,11 +110,21 @@ function isValidLatLngRange(lat: number, lng: number): boolean {
 
 function isCoordinateLike(input: string): boolean {
   const normalized = input.trim();
-  return (
-    /\d/.test(normalized) &&
-    (normalized.includes(",") ||
-      normalized.split(/\s+/).filter(Boolean).length >= 2)
+  if (!/\d/.test(normalized)) {
+    return false;
+  }
+  if (parseLatLng(normalized) !== null) {
+    return true;
+  }
+  // Comma usually indicates a lat/lng attempt even when parsing fails (e.g. "45,").
+  if (normalized.includes(",")) {
+    return true;
+  }
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  const numericTokens = tokens.filter((token) =>
+    /^-?\d+(?:\.\d+)?$/.test(token),
   );
+  return numericTokens.length >= 2;
 }
 
 function rankWatershedMatches(

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -328,7 +328,8 @@ const useStyles = tss.create(({ theme }) => ({
     border: `1px solid ${theme.palette.surface.border}`,
     boxShadow: "0 10px 26px rgba(0, 0, 0, 0.35)",
     zIndex: 1000,
-    minWidth: 400,
+    minWidth: 0,
+    width: "min(400px, calc(100vw - 110px))",
     maxWidth: "min(440px, calc(100vw - 110px))",
   },
   searchContent: {

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -43,10 +43,7 @@ type SearchCandidate = {
 };
 
 type SearchControlProps = {
-  watersheds?: GeoJSON.FeatureCollection<
-    GeoJSON.Geometry,
-    WatershedProperties
-  >;
+  watersheds?: GeoJSON.FeatureCollection<GeoJSON.Geometry, WatershedProperties>;
 };
 
 function escapeRegExp(input: string): string {
@@ -89,7 +86,7 @@ function highlightMatches(
 
 const SEARCH_FIELDS: MatchField[] = ["id", "huc", "name", "sourceName"];
 
-export function parseLatLng(input: string): [number, number] | null {
+function parseLatLng(input: string): [number, number] | null {
   const trimmed = input.trim();
   const coordsPattern = /^(-?\d+(?:\.\d+)?)\s*(?:,\s*|\s+)(-?\d+(?:\.\d+)?)$/;
   const match = trimmed.match(coordsPattern);
@@ -115,7 +112,8 @@ function isCoordinateLike(input: string): boolean {
   const normalized = input.trim();
   return (
     /\d/.test(normalized) &&
-    (normalized.includes(",") || normalized.split(/\s+/).filter(Boolean).length >= 2)
+    (normalized.includes(",") ||
+      normalized.split(/\s+/).filter(Boolean).length >= 2)
   );
 }
 
@@ -149,7 +147,10 @@ function rankWatershedMatches(
         score = 2;
       } else if (value.includes(normalized)) {
         score = 3;
-      } else if (tokens.length > 1 && tokens.every((token) => value.includes(token))) {
+      } else if (
+        tokens.length > 1 &&
+        tokens.every((token) => value.includes(token))
+      ) {
         score = 4;
       }
 
@@ -175,7 +176,9 @@ function rankWatershedMatches(
           }
         : null;
     })
-    .filter((entry): entry is SearchCandidate & { score: number } => entry !== null)
+    .filter(
+      (entry): entry is SearchCandidate & { score: number } => entry !== null,
+    )
     .sort((a, b) => {
       if (a.score !== b.score) {
         return a.score - b.score;
@@ -566,14 +569,17 @@ export default function SearchControl({ watersheds }: SearchControlProps) {
               {results.length > 0 && (
                 <List className={classes.suggestions} role="listbox">
                   {results.map((candidate, index) => {
-                    const metadata = [candidate.item.huc, candidate.item.sourceName]
+                    const metadata = [
+                      candidate.item.huc,
+                      candidate.item.sourceName,
+                    ]
                       .filter(Boolean)
                       .join(" • ");
-                      const matchedFieldValue = String(
-                        candidate.item[candidate.matchField] ?? "",
-                      ).trim();
-                      const showMatchedFieldLine =
-                        candidate.matchField !== "name" && !!matchedFieldValue;
+                    const matchedFieldValue = String(
+                      candidate.item[candidate.matchField] ?? "",
+                    ).trim();
+                    const showMatchedFieldLine =
+                      candidate.matchField !== "name" && !!matchedFieldValue;
 
                     return (
                       <ListItemButton
@@ -585,30 +591,32 @@ export default function SearchControl({ watersheds }: SearchControlProps) {
                         aria-selected={index === activeSuggestionIndex}
                       >
                         <ListItemText
-                            primary={highlightMatches(
-                              candidate.item.name,
-                              input,
-                              classes.matchHighlight,
-                            )}
-                            secondary={
-                              metadata || showMatchedFieldLine ? (
-                                <>
-                                  {metadata && (
-                                    <span className={classes.suggestionMeta}>{metadata}</span>
-                                  )}
-                                  {showMatchedFieldLine && (
-                                    <span className={classes.suggestionMeta}>
-                                      {`${candidate.matchField}: `}
-                                      {highlightMatches(
-                                        matchedFieldValue,
-                                        input,
-                                        classes.matchHighlight,
-                                      )}
-                                    </span>
-                                  )}
-                                </>
-                              ) : undefined
-                            }
+                          primary={highlightMatches(
+                            candidate.item.name,
+                            input,
+                            classes.matchHighlight,
+                          )}
+                          secondary={
+                            metadata || showMatchedFieldLine ? (
+                              <>
+                                {metadata && (
+                                  <span className={classes.suggestionMeta}>
+                                    {metadata}
+                                  </span>
+                                )}
+                                {showMatchedFieldLine && (
+                                  <span className={classes.suggestionMeta}>
+                                    {`${candidate.matchField}: `}
+                                    {highlightMatches(
+                                      matchedFieldValue,
+                                      input,
+                                      classes.matchHighlight,
+                                    )}
+                                  </span>
+                                )}
+                              </>
+                            ) : undefined
+                          }
                           className={classes.suggestionText}
                           slotProps={{
                             secondary: {

--- a/client/src/components/map/controls/Search.tsx
+++ b/client/src/components/map/controls/Search.tsx
@@ -1,10 +1,268 @@
-import { useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { useMap } from "react-leaflet";
 import { toast } from "react-toastify";
+import { useNavigate } from "@tanstack/react-router";
+import L from "leaflet";
 import { tss } from "../../../utils/tss";
-import { Button, Paper, TextField, InputAdornment } from "@mui/material";
+import { useRunId } from "../../../hooks/useRunId";
+import {
+  Button,
+  Paper,
+  TextField,
+  InputAdornment,
+  List,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import CloseIcon from "@mui/icons-material/Close";
+import type { WatershedProperties } from "../../../types/WatershedProperties";
+
+type WatershedIndexItem = {
+  id: string;
+  name: string;
+  sourceName: string;
+  huc: string;
+  center: [number, number];
+  bbox?: [number, number, number, number];
+};
+
+type MatchField = "name" | "sourceName" | "huc" | "id";
+
+type SearchCandidate = {
+  item: WatershedIndexItem;
+  matchField: MatchField;
+};
+
+type SearchControlProps = {
+  watersheds?: GeoJSON.FeatureCollection<
+    GeoJSON.Geometry,
+    WatershedProperties
+  >;
+};
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function highlightMatches(
+  text: string,
+  query: string,
+  markClassName: string,
+): ReactNode {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return text;
+  }
+
+  const tokens = normalizedQuery
+    .split(/\s+/)
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+
+  if (tokens.length === 0) {
+    return text;
+  }
+
+  const pattern = new RegExp(`(${tokens.map(escapeRegExp).join("|")})`, "ig");
+  const parts = text.split(pattern);
+
+  return parts.map((part, index) => {
+    const isMatch = tokens.some((token) => part.toLowerCase() === token);
+    return isMatch ? (
+      <mark key={`${part}-${index}`} className={markClassName}>
+        {part}
+      </mark>
+    ) : (
+      <span key={`${part}-${index}`}>{part}</span>
+    );
+  });
+}
+
+const SEARCH_FIELDS: MatchField[] = ["id", "huc", "name", "sourceName"];
+
+export function parseLatLng(input: string): [number, number] | null {
+  const trimmed = input.trim();
+  const coordsPattern = /^(-?\d+(?:\.\d+)?)\s*(?:,\s*|\s+)(-?\d+(?:\.\d+)?)$/;
+  const match = trimmed.match(coordsPattern);
+
+  if (!match) {
+    return null;
+  }
+
+  const lat = Number(match[1]);
+  const lng = Number(match[2]);
+  if (Number.isNaN(lat) || Number.isNaN(lng)) {
+    return null;
+  }
+
+  return [lat, lng];
+}
+
+function isValidLatLngRange(lat: number, lng: number): boolean {
+  return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+}
+
+function isCoordinateLike(input: string): boolean {
+  const normalized = input.trim();
+  return (
+    /\d/.test(normalized) &&
+    (normalized.includes(",") || normalized.split(/\s+/).filter(Boolean).length >= 2)
+  );
+}
+
+function rankWatershedMatches(
+  query: string,
+  index: WatershedIndexItem[],
+): SearchCandidate[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return [];
+  }
+
+  const scored = new Map<string, { score: number; matchField: MatchField }>();
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+
+  for (const item of index) {
+    for (const field of SEARCH_FIELDS) {
+      const rawValue = String(item[field] ?? "");
+      const value = rawValue.trim().toLowerCase();
+      if (!value) {
+        continue;
+      }
+
+      let score: number | null = null;
+
+      if ((field === "id" || field === "huc") && value === normalized) {
+        score = 0;
+      } else if (value === normalized) {
+        score = 1;
+      } else if (value.startsWith(normalized)) {
+        score = 2;
+      } else if (value.includes(normalized)) {
+        score = 3;
+      } else if (tokens.length > 1 && tokens.every((token) => value.includes(token))) {
+        score = 4;
+      }
+
+      if (score == null) {
+        continue;
+      }
+
+      const previous = scored.get(item.id);
+      if (!previous || score < previous.score) {
+        scored.set(item.id, { score, matchField: field });
+      }
+    }
+  }
+
+  return index
+    .map((item) => {
+      const score = scored.get(item.id);
+      return score
+        ? {
+            item,
+            matchField: score.matchField,
+            score: score.score,
+          }
+        : null;
+    })
+    .filter((entry): entry is SearchCandidate & { score: number } => entry !== null)
+    .sort((a, b) => {
+      if (a.score !== b.score) {
+        return a.score - b.score;
+      }
+
+      return a.item.name.localeCompare(b.item.name);
+    })
+    .map(({ item, matchField }) => ({ item, matchField }));
+}
+
+function collectLngLatPairs(value: unknown, pairs: [number, number][]): void {
+  if (!Array.isArray(value)) {
+    return;
+  }
+
+  if (
+    value.length >= 2 &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number"
+  ) {
+    pairs.push([value[0], value[1]]);
+    return;
+  }
+
+  for (const child of value) {
+    collectLngLatPairs(child, pairs);
+  }
+}
+
+function getBoundsFromGeometry(
+  geometry: GeoJSON.Geometry | null | undefined,
+): [number, number, number, number] | null {
+  if (!geometry) {
+    return null;
+  }
+
+  const pairs: [number, number][] = [];
+  collectLngLatPairs((geometry as GeoJSON.Geometry).coordinates, pairs);
+
+  if (pairs.length === 0) {
+    return null;
+  }
+
+  let west = Infinity;
+  let east = -Infinity;
+  let south = Infinity;
+  let north = -Infinity;
+
+  for (const [lng, lat] of pairs) {
+    west = Math.min(west, lng);
+    east = Math.max(east, lng);
+    south = Math.min(south, lat);
+    north = Math.max(north, lat);
+  }
+
+  return [south, west, north, east];
+}
+
+function toSearchIndex(
+  watersheds?: GeoJSON.FeatureCollection<GeoJSON.Geometry, WatershedProperties>,
+): WatershedIndexItem[] {
+  if (!watersheds?.features?.length) {
+    return [];
+  }
+
+  return watersheds.features
+    .map((feature) => {
+      const bbox = getBoundsFromGeometry(feature.geometry);
+      if (!bbox) {
+        return null;
+      }
+
+      const [south, west, north, east] = bbox;
+      const center: [number, number] = [(south + north) / 2, (west + east) / 2];
+      const props = feature.properties;
+
+      return {
+        id: String(feature.id ?? props.pws_id ?? ""),
+        name: props.pws_name ?? props.huc10_name ?? "Unknown Watershed",
+        sourceName: props.srcname ?? "",
+        huc: props.huc10_id ?? "",
+        center,
+        bbox,
+      } satisfies WatershedIndexItem;
+    })
+    .filter((item): item is WatershedIndexItem => item !== null && !!item.id);
+}
 
 const useStyles = tss.create(({ theme }) => ({
   searchButton: {
@@ -34,46 +292,98 @@ const useStyles = tss.create(({ theme }) => ({
     position: "absolute",
     top: 0,
     right: 60,
-    background: theme.palette.surface.overlay,
-    color: theme.palette.primary.contrastText,
-    padding: theme.spacing(1),
+    background: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    padding: theme.spacing(1.25),
     borderRadius: theme.spacing(1),
-    boxShadow: "0 2px 10px rgba(0, 0, 0, 0.5)",
+    border: `1px solid ${theme.palette.surface.border}`,
+    boxShadow: "0 10px 26px rgba(0, 0, 0, 0.35)",
     zIndex: 1000,
+    minWidth: 400,
+    maxWidth: "min(440px, calc(100vw - 110px))",
   },
   searchContent: {
     display: "flex",
     alignItems: "center",
     gap: theme.spacing(1.5),
   },
+  searchBody: {
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.spacing(0.75),
+  },
+  searchHeading: {
+    fontSize: theme.typography.caption.fontSize,
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    color: theme.palette.text.secondary,
+  },
   searchInput: {
-    minWidth: 260,
+    minWidth: 0,
+    flex: 1,
     "& .MuiInputBase-root": {
       height: 40,
-      backgroundColor: theme.palette.accent.contrastText,
-      color: theme.palette.secondary.main,
+      backgroundColor: theme.palette.background.default,
+      color: theme.palette.text.primary,
       borderRadius: theme.spacing(0.5),
       paddingLeft: theme.spacing(1),
     },
+    "& .MuiInputBase-input::placeholder": {
+      color: theme.palette.text.secondary,
+      opacity: 0.72,
+      fontSize: "0.9rem",
+      fontWeight: 400,
+    },
     "& .MuiOutlinedInput-notchedOutline": {
-      border: `1px solid ${theme.palette.primary.contrastText}`,
+      border: `1px solid ${theme.palette.surface.border}`,
     },
   },
   inputIcon: {
-    color: theme.palette.secondary.main,
+    color: theme.palette.text.secondary,
     fontSize: 20,
   },
   goButton: {
     fontSize: theme.typography.body2.fontSize,
     transitionDuration: "0.4s",
-    backgroundColor: theme.palette.primary.contrastText,
-    color: theme.palette.primary.dark,
+    backgroundColor: theme.palette.accent.main,
+    color: theme.palette.accent.contrastText,
     minWidth: "auto",
     padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
     height: 40,
     "&:hover": {
-      backgroundColor: theme.palette.primary.light,
+      backgroundColor: theme.palette.accent.dark,
     },
+  },
+  suggestions: {
+    marginTop: theme.spacing(0.25),
+    maxHeight: 220,
+    overflowY: "auto",
+    backgroundColor: theme.palette.background.default,
+    borderRadius: theme.spacing(0.5),
+    border: `1px solid ${theme.palette.surface.border}`,
+  },
+  suggestionItem: {
+    "& + &": {
+      borderTop: `1px solid ${
+        theme.palette.mode === "dark"
+          ? "rgba(255, 255, 255, 0.08)"
+          : "rgba(0, 0, 0, 0.08)"
+      }`,
+    },
+  },
+  suggestionText: {
+    color: theme.palette.text.primary,
+    margin: 0,
+  },
+  suggestionMeta: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize,
+    display: "block",
+    lineHeight: 1.3,
+  },
+  matchHighlight: {
+    backgroundColor: theme.palette.accent.main,
+    color: theme.palette.accent.contrastText,
   },
 }));
 
@@ -82,33 +392,126 @@ const useStyles = tss.create(({ theme }) => ({
  *
  * @component
  */
-export default function SearchControl() {
+export default function SearchControl({ watersheds }: SearchControlProps) {
   const map = useMap();
+  const navigate = useNavigate();
+  const runId = useRunId();
   const { classes } = useStyles();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+
+    // Keep control interactions (click, drag, wheel) from leaking to the map.
+    L.DomEvent.disableClickPropagation(root);
+    L.DomEvent.disableScrollPropagation(root);
+  }, []);
 
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [input, setInput] = useState("");
+  const [results, setResults] = useState<SearchCandidate[]>([]);
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
+
+  const searchIndex = useMemo(() => toSearchIndex(watersheds), [watersheds]);
+
+  const clearSearchState = () => {
+    setInput("");
+    setResults([]);
+    setActiveSuggestionIndex(0);
+  };
+
+  const closeAndReset = () => {
+    clearSearchState();
+    setIsSearchOpen(false);
+  };
+
+  const selectWatershed = (candidate: SearchCandidate) => {
+    navigate({ to: `/watershed/${candidate.item.id}` });
+
+    closeAndReset();
+  };
 
   const handleSearch = () => {
-    const [lat, lng] = input
-      .split(",")
-      .map((coord) => parseFloat(coord.trim()));
-    if (!isNaN(lat) && !isNaN(lng)) {
+    const trimmedInput = input.trim();
+    const normalizedQuery = trimmedInput.toLowerCase();
+    if (!normalizedQuery) {
+      return;
+    }
+
+    const coords = parseLatLng(trimmedInput);
+    if (coords) {
+      const [lat, lng] = coords;
+      if (!isValidLatLngRange(lat, lng)) {
+        toast.error(
+          "Invalid coordinate range. Latitude must be between -90 and 90, longitude between -180 and 180.",
+        );
+        return;
+      }
       map.setView([lat, lng], 13);
-      setInput("");
-      setIsSearchOpen(false);
-    } else {
+      if (runId) {
+        navigate({ to: "/" });
+      }
+      closeAndReset();
+      return;
+    }
+
+    if (isCoordinateLike(trimmedInput)) {
       toast.error(
         'Invalid coordinates. Please enter in "latitude, longitude" format.',
       );
+      return;
+    }
+
+    const matches = rankWatershedMatches(normalizedQuery, searchIndex);
+    if (matches.length === 0) {
+      setResults([]);
+      toast.error("No watershed match found. Try coordinates or another name.");
+      return;
+    }
+
+    setResults(matches);
+    setActiveSuggestionIndex(0);
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown" && results.length > 0) {
+      event.preventDefault();
+      setActiveSuggestionIndex((current) => (current + 1) % results.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp" && results.length > 0) {
+      event.preventDefault();
+      setActiveSuggestionIndex((current) =>
+        current === 0 ? results.length - 1 : current - 1,
+      );
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (results.length > 0) {
+        selectWatershed(results[activeSuggestionIndex]);
+      } else {
+        handleSearch();
+      }
     }
   };
 
   return (
     <>
-      <div className="leaflet-bar leaflet-control">
+      <div className="leaflet-bar leaflet-control" ref={rootRef}>
         <Button
-          onClick={() => setIsSearchOpen(!isSearchOpen)}
+          onClick={() => {
+            if (isSearchOpen) {
+              closeAndReset();
+            } else {
+              setIsSearchOpen(true);
+            }
+          }}
           className={classes.searchButton}
           aria-label="Search location"
           title="Search location"
@@ -122,33 +525,102 @@ export default function SearchControl() {
 
         {isSearchOpen && (
           <Paper className={classes.searchModal}>
-            <div className={classes.searchContent}>
-              <TextField
-                size="small"
-                placeholder="Search coordinates"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                className={classes.searchInput}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <SearchIcon className={classes.inputIcon} />
-                      </InputAdornment>
-                    ),
-                  },
-                  htmlInput: {
-                    "aria-label": "Search bar",
-                  },
-                }}
-              />
-              <Button
-                onClick={handleSearch}
-                className={classes.goButton}
-                aria-label="Go button"
-              >
-                Go
-              </Button>
+            <div className={classes.searchBody}>
+              <Typography className={classes.searchHeading}>
+                Find Watershed
+              </Typography>
+              <div className={classes.searchContent}>
+                <TextField
+                  size="small"
+                  placeholder="Coordinates or watershed"
+                  value={input}
+                  onChange={(e) => {
+                    setInput(e.target.value);
+                    setResults([]);
+                    setActiveSuggestionIndex(0);
+                  }}
+                  onKeyDown={handleInputKeyDown}
+                  className={classes.searchInput}
+                  slotProps={{
+                    input: {
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          <SearchIcon className={classes.inputIcon} />
+                        </InputAdornment>
+                      ),
+                    },
+                    htmlInput: {
+                      "aria-label": "Search bar",
+                    },
+                  }}
+                />
+                <Button
+                  onClick={handleSearch}
+                  className={classes.goButton}
+                  aria-label="Go button"
+                >
+                  Go
+                </Button>
+              </div>
+
+              {results.length > 0 && (
+                <List className={classes.suggestions} role="listbox">
+                  {results.map((candidate, index) => {
+                    const metadata = [candidate.item.huc, candidate.item.sourceName]
+                      .filter(Boolean)
+                      .join(" • ");
+                      const matchedFieldValue = String(
+                        candidate.item[candidate.matchField] ?? "",
+                      ).trim();
+                      const showMatchedFieldLine =
+                        candidate.matchField !== "name" && !!matchedFieldValue;
+
+                    return (
+                      <ListItemButton
+                        key={candidate.item.id}
+                        className={classes.suggestionItem}
+                        selected={index === activeSuggestionIndex}
+                        onClick={() => selectWatershed(candidate)}
+                        role="option"
+                        aria-selected={index === activeSuggestionIndex}
+                      >
+                        <ListItemText
+                            primary={highlightMatches(
+                              candidate.item.name,
+                              input,
+                              classes.matchHighlight,
+                            )}
+                            secondary={
+                              metadata || showMatchedFieldLine ? (
+                                <>
+                                  {metadata && (
+                                    <span className={classes.suggestionMeta}>{metadata}</span>
+                                  )}
+                                  {showMatchedFieldLine && (
+                                    <span className={classes.suggestionMeta}>
+                                      {`${candidate.matchField}: `}
+                                      {highlightMatches(
+                                        matchedFieldValue,
+                                        input,
+                                        classes.matchHighlight,
+                                      )}
+                                    </span>
+                                  )}
+                                </>
+                              ) : undefined
+                            }
+                          className={classes.suggestionText}
+                          slotProps={{
+                            secondary: {
+                              className: classes.suggestionMeta,
+                            },
+                          }}
+                        />
+                      </ListItemButton>
+                    );
+                  })}
+                </List>
+              )}
             </div>
           </Paper>
         )}

--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -285,21 +285,21 @@ export default function WatershedOverview() {
         {(watershed?.properties?.owner_type ||
           watershed?.properties?.pop_group ||
           watershed?.properties?.treat_type) && (
-            <>
-              <Typography variant="body1" className={classes.paragraph}>
-                <strong>Water Utility Type: </strong>
-                {watershed?.properties?.owner_type ?? "N/A"}
-              </Typography>
-              <Typography variant="body1" className={classes.paragraph}>
-                <strong>Customers Served: </strong>
-                {watershed?.properties?.pop_group ?? "N/A"}
-              </Typography>
-              <Typography variant="body1" className={classes.paragraph}>
-                <strong>Treatment Processes: </strong>
-                {watershed?.properties?.treat_type ?? "N/A"}
-              </Typography>
-            </>
-          )}
+          <>
+            <Typography variant="body1" className={classes.paragraph}>
+              <strong>Water Utility Type: </strong>
+              {watershed?.properties?.owner_type ?? "N/A"}
+            </Typography>
+            <Typography variant="body1" className={classes.paragraph}>
+              <strong>Customers Served: </strong>
+              {watershed?.properties?.pop_group ?? "N/A"}
+            </Typography>
+            <Typography variant="body1" className={classes.paragraph}>
+              <strong>Treatment Processes: </strong>
+              {watershed?.properties?.treat_type ?? "N/A"}
+            </Typography>
+          </>
+        )}
       </div>
 
       <div className={classes.modelsBox}>

--- a/client/src/hooks/useRhessysChoroplethData.ts
+++ b/client/src/hooks/useRhessysChoroplethData.ts
@@ -62,7 +62,10 @@ export function useRhessysChoroplethData() {
     placeholderData: keepPreviousData,
   });
 
-  const patchGeometryRevision = getPatchGeometryRevision(spatialScale, scenario);
+  const patchGeometryRevision = getPatchGeometryRevision(
+    spatialScale,
+    scenario,
+  );
   const geometryQueryScenario = getPatchGeometryQueryScenario(
     patchGeometryRevision,
   );
@@ -74,12 +77,7 @@ export function useRhessysChoroplethData() {
       patchGeometryRevision,
     ),
     queryFn: ({ signal }) =>
-      fetchRhessysGeometry(
-        runId!,
-        spatialScale,
-        signal,
-        geometryQueryScenario,
-      ),
+      fetchRhessysGeometry(runId!, spatialScale, signal, geometryQueryScenario),
     enabled: isActive && !!runId,
     placeholderData: keepPreviousData,
   });

--- a/client/src/tests/Search.test.tsx
+++ b/client/src/tests/Search.test.tsx
@@ -2,15 +2,28 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { toast } from "react-toastify";
 import Search from "../components/map/controls/Search";
+import type { WatershedProperties } from "../types/WatershedProperties";
 
 const mockSetView = vi.fn();
+const mockNavigate = vi.fn();
+const mockUseRunId = vi.fn(() => null);
 
 vi.mock("react-leaflet", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-leaflet")>();
   return Object.assign({}, actual, {
-    useMap: () => ({ setView: mockSetView }),
+    useMap: () => ({
+      setView: mockSetView,
+    }),
   });
 });
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("../hooks/useRunId", () => ({
+  useRunId: () => mockUseRunId(),
+}));
 
 vi.mock("react-toastify", () => ({
   toast: {
@@ -20,26 +33,145 @@ vi.mock("react-toastify", () => ({
 
 const toastErrorMock = vi.mocked(toast.error);
 
+const makeWatershedProps = (
+  overrides: Partial<WatershedProperties>,
+): WatershedProperties => ({
+  pws_id: "",
+  srcname: "",
+  pws_name: "",
+  county_nam: "",
+  state: null,
+  huc10_id: "",
+  huc10_name: "",
+  wws_code: "",
+  srctype: "",
+  shape_leng: 0,
+  shape_area: 0,
+  owner_type: null,
+  pop_group: null,
+  treat_type: null,
+  conn_group: null,
+  huc10_pws_names: null,
+  huc10_owner_types: null,
+  huc10_pop_groups: null,
+  huc10_treat_types: null,
+  huc10_utility_count: null,
+  ...overrides,
+});
+
+const testWatersheds: GeoJSON.FeatureCollection<
+  GeoJSON.Geometry,
+  WatershedProperties
+> = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      id: "gate-creek-001",
+      properties: makeWatershedProps({
+        pws_name: "South Fork Basin",
+        srcname: "Gate Creek",
+        huc10_id: "170703010101",
+      }),
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-121.8, 44.15],
+            [-121.7, 44.15],
+            [-121.7, 44.23],
+            [-121.8, 44.23],
+            [-121.8, 44.15],
+          ],
+        ],
+      },
+    },
+    {
+      type: "Feature",
+      id: "clear-creek-001",
+      properties: makeWatershedProps({
+        pws_name: "Clear Creek",
+        srcname: "Clear Creek",
+        huc10_id: "170703010102",
+      }),
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-121.67, 44.08],
+            [-121.58, 44.08],
+            [-121.58, 44.16],
+            [-121.67, 44.16],
+            [-121.67, 44.08],
+          ],
+        ],
+      },
+    },
+    {
+      type: "Feature",
+      id: "clear-lake-002",
+      properties: makeWatershedProps({
+        pws_name: "Clear Lake",
+        srcname: "Clear Lake Tributary",
+        huc10_id: "170703010103",
+      }),
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-121.56, 43.98],
+            [-121.48, 43.98],
+            [-121.48, 44.06],
+            [-121.56, 44.06],
+            [-121.56, 43.98],
+          ],
+        ],
+      },
+    },
+    {
+      type: "Feature",
+      id: "pine-river-003",
+      properties: makeWatershedProps({
+        pws_name: "Pine River",
+        srcname: "Pine River",
+        huc10_id: "170703010104",
+      }),
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-121.44, 43.94],
+            [-121.36, 43.94],
+            [-121.36, 43.98],
+            [-121.44, 43.98],
+            [-121.44, 43.94],
+          ],
+        ],
+      },
+    },
+  ],
+};
+
 describe("Search Component Tests", () => {
   beforeEach(() => {
-    mockSetView.mockClear();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    mockUseRunId.mockReturnValue(null);
   });
 
   describe("rendering", () => {
     it("renders without crashing", () => {
-      render(<Search />);
+      render(<Search watersheds={testWatersheds} />);
     });
 
     it("does not show the search modal by default", () => {
-      render(<Search />);
+      render(<Search watersheds={testWatersheds} />);
       expect(screen.queryByLabelText("Search bar")).not.toBeInTheDocument();
     });
   });
 
   describe("interactions", () => {
     it("opens and closes the modal when clicking the search button", () => {
-      render(<Search />);
+      render(<Search watersheds={testWatersheds} />);
 
       const toggleButton = screen.getByRole("button", {
         name: /search location/i,
@@ -54,7 +186,7 @@ describe("Search Component Tests", () => {
     });
 
     it("calls map.setView with parsed coordinates and closes modal on valid input", () => {
-      render(<Search />);
+      render(<Search watersheds={testWatersheds} />);
 
       fireEvent.click(screen.getByRole("button", { name: /search location/i }));
       const input = screen.getByLabelText("Search bar") as HTMLInputElement;
@@ -75,12 +207,27 @@ describe("Search Component Tests", () => {
       ).toBe("");
     });
 
-    it("shows toast error and does not call setView on invalid input", () => {
-      render(<Search />);
+    it("navigates home before leaving search context on coordinate search from watershed route", () => {
+      mockUseRunId.mockReturnValue("gate-creek-001");
+      render(<Search watersheds={testWatersheds} />);
 
       fireEvent.click(screen.getByRole("button", { name: /search location/i }));
       fireEvent.change(screen.getByLabelText("Search bar"), {
-        target: { value: "not coords" },
+        target: { value: "0, 0" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      expect(mockSetView).toHaveBeenCalledTimes(1);
+      expect(mockSetView).toHaveBeenCalledWith([0, 0], 13);
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+    });
+
+    it("shows toast error and does not call setView on invalid coordinate input", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "45," },
       });
       fireEvent.click(screen.getByRole("button", { name: /go button/i }));
 
@@ -92,6 +239,89 @@ describe("Search Component Tests", () => {
 
       // Modal should stay open on invalid input
       expect(screen.getByLabelText("Search bar")).toBeInTheDocument();
+    });
+
+    it("shows toast error and does not call setView on out-of-range coordinates", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "1000, 1000" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Invalid coordinate range. Latitude must be between -90 and 90, longitude between -180 and 180.",
+      );
+      expect(mockSetView).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("Search bar")).toBeInTheDocument();
+    });
+
+    it("shows a single explicit option for unique watershed matches", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "south fork basin" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(1);
+      expect(screen.getByText("South Fork Basin")).toBeInTheDocument();
+      expect(screen.getByText("170703010101 • Gate Creek")).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockSetView).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("Search bar")).toBeInTheDocument();
+    });
+
+    it("shows suggestions for multiple watershed matches", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "clear" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      const options = screen.getAllByRole("option");
+      expect(options.length).toBeGreaterThan(1);
+      expect(screen.getByText("Clear Creek")).toBeInTheDocument();
+      expect(screen.getByText("Clear Lake")).toBeInTheDocument();
+      expect(mockSetView).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("shows no-match toast when watershed query has no hits", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "unknown watershed" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "No watershed match found. Try coordinates or another name.",
+      );
+      expect(mockSetView).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("includes matched attribute/value for sourceName matches", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "creek" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      expect(screen.getByText(/sourceName:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Gate Creek/i)).toBeInTheDocument();
+      expect(document.querySelectorAll("mark").length).toBeGreaterThan(0);
     });
   });
 });

--- a/client/src/tests/Search.test.tsx
+++ b/client/src/tests/Search.test.tsx
@@ -269,8 +269,8 @@ describe("Search Component Tests", () => {
 
       const options = screen.getAllByRole("option");
       expect(options).toHaveLength(1);
-      expect(screen.getByText("South Fork Basin")).toBeInTheDocument();
-      expect(screen.getByText("170703010101 • Gate Creek")).toBeInTheDocument();
+      expect(options[0]).toHaveTextContent("South Fork Basin");
+      expect(options[0]).toHaveTextContent("170703010101 • Gate Creek");
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockSetView).not.toHaveBeenCalled();
       expect(screen.getByLabelText("Search bar")).toBeInTheDocument();
@@ -287,8 +287,8 @@ describe("Search Component Tests", () => {
 
       const options = screen.getAllByRole("option");
       expect(options.length).toBeGreaterThan(1);
-      expect(screen.getByText("Clear Creek")).toBeInTheDocument();
-      expect(screen.getByText("Clear Lake")).toBeInTheDocument();
+      expect(options[0]).toHaveTextContent("Clear Creek");
+      expect(options[1]).toHaveTextContent("Clear Lake");
       expect(mockSetView).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
     });
@@ -315,12 +315,13 @@ describe("Search Component Tests", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /search location/i }));
       fireEvent.change(screen.getByLabelText("Search bar"), {
-        target: { value: "creek" },
+        target: { value: "tributary" },
       });
       fireEvent.click(screen.getByRole("button", { name: /go button/i }));
 
-      expect(screen.getByText(/sourceName:/i)).toBeInTheDocument();
-      expect(screen.getByText(/Gate Creek/i)).toBeInTheDocument();
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveTextContent("sourceName:");
+      expect(options[0]).toHaveTextContent("Clear Lake Tributary");
       expect(document.querySelectorAll("mark").length).toBeGreaterThan(0);
     });
   });

--- a/client/src/tests/Search.test.tsx
+++ b/client/src/tests/Search.test.tsx
@@ -6,7 +6,7 @@ import type { WatershedProperties } from "../types/WatershedProperties";
 
 const mockSetView = vi.fn();
 const mockNavigate = vi.fn();
-const mockUseRunId = vi.fn(() => null);
+const mockUseRunId = vi.fn<() => string | null>(() => null);
 
 vi.mock("react-leaflet", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-leaflet")>();

--- a/client/src/tests/Search.test.tsx
+++ b/client/src/tests/Search.test.tsx
@@ -346,6 +346,26 @@ describe("Search Component Tests", () => {
       expect(options[0]).toHaveTextContent("Deer Creek 2");
     });
 
+    it("shows loading/unavailable toast when watershed data is missing", () => {
+      const emptyCollection: GeoJSON.FeatureCollection<
+        GeoJSON.Geometry,
+        WatershedProperties
+      > = { type: "FeatureCollection", features: [] };
+
+      render(<Search watersheds={emptyCollection} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "clear creek" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Watershed data is still loading or unavailable. Try coordinates.",
+      );
+    });
+
     it("includes matched attribute/value for sourceName matches", () => {
       render(<Search watersheds={testWatersheds} />);
 

--- a/client/src/tests/Search.test.tsx
+++ b/client/src/tests/Search.test.tsx
@@ -149,6 +149,27 @@ const testWatersheds: GeoJSON.FeatureCollection<
         ],
       },
     },
+    {
+      type: "Feature",
+      id: "deer-creek-2",
+      properties: makeWatershedProps({
+        pws_name: "Deer Creek 2",
+        srcname: "North Fork",
+        huc10_id: "170703010105",
+      }),
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-121.5, 44.0],
+            [-121.42, 44.0],
+            [-121.42, 44.05],
+            [-121.5, 44.05],
+            [-121.5, 44.0],
+          ],
+        ],
+      },
+    },
   ],
 };
 
@@ -308,6 +329,21 @@ describe("Search Component Tests", () => {
       );
       expect(mockSetView).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("does not treat name-with-number watershed queries as invalid coordinates", () => {
+      render(<Search watersheds={testWatersheds} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /search location/i }));
+      fireEvent.change(screen.getByLabelText("Search bar"), {
+        target: { value: "deer creek 2" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /go button/i }));
+
+      expect(toastErrorMock).not.toHaveBeenCalled();
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent("Deer Creek 2");
     });
 
     it("includes matched attribute/value for sourceName matches", () => {

--- a/client/src/tests/Search.test.tsx
+++ b/client/src/tests/Search.test.tsx
@@ -254,7 +254,7 @@ describe("Search Component Tests", () => {
 
       expect(toastErrorMock).toHaveBeenCalledTimes(1);
       expect(toastErrorMock).toHaveBeenCalledWith(
-        'Invalid coordinates. Please enter in "latitude, longitude" format.',
+        'Invalid coordinates. Use "latitude, longitude" or "latitude longitude".',
       );
       expect(mockSetView).not.toHaveBeenCalled();
 

--- a/client/src/tests/WatershedOverview.test.tsx
+++ b/client/src/tests/WatershedOverview.test.tsx
@@ -96,7 +96,7 @@ describe("WatershedOverview", () => {
   describe("loading state", () => {
     it("renders skeleton panel while loading", () => {
       mockUseParams.mockReturnValue("test-watershed-123");
-      mockFetchWatersheds.mockReturnValue(new Promise(() => { })); // Never resolves
+      mockFetchWatersheds.mockReturnValue(new Promise(() => {})); // Never resolves
 
       renderWithProviders(<WatershedOverview />);
 
@@ -107,7 +107,7 @@ describe("WatershedOverview", () => {
 
     it("renders skeleton buttons while loading", () => {
       mockUseParams.mockReturnValue("test-watershed-123");
-      mockFetchWatersheds.mockReturnValue(new Promise(() => { }));
+      mockFetchWatersheds.mockReturnValue(new Promise(() => {}));
 
       renderWithProviders(<WatershedOverview />);
 
@@ -216,7 +216,6 @@ describe("WatershedOverview", () => {
         expect(screen.getByText("Impact Assessment")).toBeInTheDocument();
       });
     });
-
   });
 
   describe("navigation", () => {


### PR DESCRIPTION
This pull request enhances the `Search` component and its test suite by introducing support for searching through watershed data, improving coordinate validation, and expanding test coverage for different search scenarios. The changes primarily focus on passing watershed data into the search control, updating the test setup, and adding tests for watershed and coordinate search behaviors.

**Key changes include:**

**Search functionality and integration:**
- The `SearchControl` component is now passed a `watersheds` prop from `WatershedMap`, enabling it to search and suggest watershed features.

**Test suite improvements and new test data:**
- The `Search` component tests are refactored to accept a `watersheds` prop, and a helper (`makeWatershedProps`) plus a `testWatersheds` GeoJSON fixture are added to simulate realistic search scenarios.
- Mocks for navigation and context hooks are introduced to simulate routing and context-dependent behavior in tests.

**Expanded search behavior test coverage:**
- New tests verify:
  - Navigating home before leaving the search context when searching by coordinates from a watershed route.
  - Proper error handling for invalid and out-of-range coordinates, including user feedback via toasts.
  - Watershed search suggestions, including unique and multiple matches, and handling of no matches.
  - Highlighting of matched attributes/values (e.g., `sourceName`) in search results.
This pull request enhances the test coverage and robustness of the `Search` component in the map interface, especially for watershed search functionality. It introduces a realistic set of test watersheds, mocks relevant hooks and navigation, and adds comprehensive tests for searching by coordinates and watershed names, including edge cases and error handling.

**Testing and Mocking Improvements:**

* Added a `testWatersheds` GeoJSON dataset and a utility function `makeWatershedProps` to provide realistic watershed data for tests.
* Mocked `useNavigate` from `@tanstack/react-router` and `useRunId` hook to simulate navigation and context-dependent behavior in tests.

**Expanded Search Component Test Coverage:**

* Added tests for coordinate search from a watershed context, ensuring navigation to home before leaving the current watershed.
* Added tests for invalid and out-of-range coordinate input, verifying correct error toast messages and modal behavior. [[1]](diffhunk://#diff-f7b58dff36820e58ae8d3bb9d3dd59f201093168ef07635fab55a4d1a0235e1cL78-R230) [[2]](diffhunk://#diff-f7b58dff36820e58ae8d3bb9d3dd59f201093168ef07635fab55a4d1a0235e1cR243-R325)
* Added tests for watershed name search, including unique and multiple matches, no matches, and attribute highlighting in results.

**Component Prop Update:**

* Updated `WatershedMap` to pass the `watersheds` prop to `SearchControl`, ensuring the search component receives necessary data.