### PR TITLE
Add RXFire report dropdown to WatershedOverview and enhance styles

### DIFF
--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -19,6 +19,8 @@ import DownloadIcon from "@mui/icons-material/Download";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import Collapse from "@mui/material/Collapse";
+import Divider from "@mui/material/Divider";
+import { alpha } from "@mui/material/styles";
 import WeppSection from "./sections/WeppSection";
 import WatershedDataSection from "./sections/WatershedDataSection";
 import RhessysSection from "./sections/RhessysSection";
@@ -45,6 +47,33 @@ const useStyles = tss.create(({ theme }) => ({
   sectionHeading: {
     fontWeight: 600,
     marginBottom: theme.spacing(1),
+    fontSize: theme.typography.h6.fontSize,
+  },
+  sectionSubheading: {
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: "0.06em",
+    marginBottom: theme.spacing(1),
+    color: alpha(theme.palette.primary.contrastText, 0.9),
+  },
+  sectionSubgroup: {
+    padding: theme.spacing(1.25),
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${alpha(theme.palette.primary.contrastText, 0.2)}`,
+    background:
+      `linear-gradient(180deg, ${alpha(theme.palette.primary.contrastText, 0.1)} 0%, ${alpha(theme.palette.primary.contrastText, 0.04)} 100%)`,
+  },
+  sectionSubgroupControls: {
+    marginBottom: theme.spacing(1.5),
+  },
+  sectionSubgroupLinks: {
+    marginTop: theme.spacing(1.5),
+  },
+  sectionDivider: {
+    borderColor: alpha(theme.palette.primary.contrastText, 0.24),
+    marginTop: theme.spacing(1.5),
+    marginBottom: theme.spacing(1.5),
   },
   emptyState: {
     fontSize: theme.typography.body2.fontSize,
@@ -53,15 +82,15 @@ const useStyles = tss.create(({ theme }) => ({
   },
   title: {
     marginBottom: theme.spacing(1.5),
-    fontSize: theme.typography.h3.fontSize,
+    fontSize: theme.typography.h2.fontSize,
   },
   titleMulti: {
     marginBottom: theme.spacing(1),
-    fontSize: `calc((${theme.typography.h3.fontSize} + ${theme.typography.h4.fontSize}) / 2)`,
+    fontSize: `calc((${theme.typography.h2.fontSize} + ${theme.typography.h3.fontSize}) / 2)`,
   },
   paragraph: {
     marginBottom: theme.spacing(2),
-    fontSize: theme.typography.body1.fontSize,
+    fontSize: theme.typography.h6.fontSize,
   },
   actionLink: {
     fontSize: theme.typography.body2.fontSize,
@@ -109,10 +138,10 @@ const useStyles = tss.create(({ theme }) => ({
     appearance: "none",
     WebkitAppearance: "none",
     padding: theme.spacing(0.75, 1),
-    border: "1px solid rgba(255, 255, 255, 0.2)",
+    border: `1px solid ${alpha(theme.palette.primary.contrastText, 0.28)}`,
     borderRadius: theme.shape.borderRadius,
     "&:hover": {
-      backgroundColor: "rgba(255, 255, 255, 0.06)",
+      backgroundColor: alpha(theme.palette.primary.contrastText, 0.12),
     },
   },
   reportDropdownLabel: {
@@ -122,6 +151,11 @@ const useStyles = tss.create(({ theme }) => ({
   reportDropdownLinks: {
     paddingLeft: theme.spacing(1),
     paddingTop: theme.spacing(0.75),
+  },
+  linksHint: {
+    fontSize: theme.typography.body2.fontSize,
+    color: alpha(theme.palette.primary.contrastText, 0.82),
+    marginBottom: theme.spacing(1),
   },
 }));
 
@@ -361,77 +395,99 @@ export default function WatershedOverview() {
           <Typography variant="body1" className={classes.sectionHeading}>
             Short Term Impact
           </Typography>
-          <Link
-            href={runId ? API_ENDPOINTS.WEPP_DASHBOARD(runId) : undefined}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={classes.actionLink}
-            underline="always"
-            aria-label="View WEPP model dashboard"
+
+          <div
+            className={`${classes.sectionSubgroup} ${classes.sectionSubgroupControls}`}
           >
-            View WEPP model dashboard
-          </Link>
-          <Link
-            href={runId ? API_ENDPOINTS.WEPP_DEVAL_DETAILS(runId) : undefined}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={classes.actionLink}
-            underline="always"
-            aria-label="View WEPP interactive report"
+            <Typography className={classes.sectionSubheading}>
+              Map Controls
+            </Typography>
+            <WeppSection />
+          </div>
+
+          <Divider className={classes.sectionDivider} />
+
+          <div
+            className={`${classes.sectionSubgroup} ${classes.sectionSubgroupLinks}`}
           >
-            View WEPP interactive report
-          </Link>
-          {runId === MILLCREEK_RUN_ID && (
-            <div className={classes.reportDropdownWrapper}>
-              <button
-                className={classes.reportDropdownHeader}
-                onClick={() => setRxfireOpen((prev) => !prev)}
-                aria-expanded={rxfireOpen}
-                aria-controls="rxfire-links"
-              >
-                <Typography className={classes.reportDropdownLabel}>
-                  Site Specific Prescribed Fire Scenarios
-                </Typography>
-                {rxfireOpen ? (
-                  <ExpandLessIcon fontSize="small" />
-                ) : (
-                  <ExpandMoreIcon fontSize="small" />
-                )}
-              </button>
-              <Collapse in={rxfireOpen}>
-                <div id="rxfire-links" className={classes.reportDropdownLinks}>
-                  <Link
-                    href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Manager_Defined.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={classes.actionLink}
-                    underline="always"
-                  >
-                    Manager Defined
-                  </Link>
-                  <Link
-                    href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Stream_Order_2.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={classes.actionLink}
-                    underline="always"
-                  >
-                    Stream Order 2
-                  </Link>
-                  <Link
-                    href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Stream_Order_3.html"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={classes.actionLink}
-                    underline="always"
-                  >
-                    Stream Order 3
-                  </Link>
-                </div>
-              </Collapse>
-            </div>
-          )}
-          <WeppSection />
+            <Typography className={classes.sectionSubheading}>
+              Links and Reports
+            </Typography>
+            <Typography className={classes.linksHint}>
+              Open model dashboards and downloadable reports.
+            </Typography>
+            <Link
+              href={runId ? API_ENDPOINTS.WEPP_DASHBOARD(runId) : undefined}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={classes.actionLink}
+              underline="always"
+              aria-label="View WEPP model dashboard"
+            >
+              View WEPP model dashboard
+            </Link>
+            <Link
+              href={runId ? API_ENDPOINTS.WEPP_DEVAL_DETAILS(runId) : undefined}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={classes.actionLink}
+              underline="always"
+              aria-label="View WEPP interactive report"
+            >
+              View WEPP interactive report
+            </Link>
+            {runId === MILLCREEK_RUN_ID && (
+              <div className={classes.reportDropdownWrapper}>
+                <button
+                  type="button"
+                  className={classes.reportDropdownHeader}
+                  onClick={() => setRxfireOpen((prev) => !prev)}
+                  aria-expanded={rxfireOpen}
+                  aria-controls="rxfire-links"
+                >
+                  <Typography className={classes.reportDropdownLabel}>
+                    Site Specific Prescribed Fire Scenarios
+                  </Typography>
+                  {rxfireOpen ? (
+                    <ExpandLessIcon fontSize="small" />
+                  ) : (
+                    <ExpandMoreIcon fontSize="small" />
+                  )}
+                </button>
+                <Collapse in={rxfireOpen}>
+                  <div id="rxfire-links" className={classes.reportDropdownLinks}>
+                    <Link
+                      href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Manager_Defined.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={classes.actionLink}
+                      underline="always"
+                    >
+                      Manager Defined
+                    </Link>
+                    <Link
+                      href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Stream_Order_2.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={classes.actionLink}
+                      underline="always"
+                    >
+                      Stream Order 2
+                    </Link>
+                    <Link
+                      href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Stream_Order_3.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={classes.actionLink}
+                      underline="always"
+                    >
+                      Stream Order 3
+                    </Link>
+                  </div>
+                </Collapse>
+              </div>
+            )}
+          </div>
         </Paper>
 
         {hasNoLongTermData ? null : (
@@ -439,8 +495,29 @@ export default function WatershedOverview() {
             <Typography variant="body1" className={classes.sectionHeading}>
               Long Term Impact
             </Typography>
-            <RhessysSection />
-            <RhessysOutputsSection />
+
+            <div
+              className={`${classes.sectionSubgroup} ${classes.sectionSubgroupControls}`}
+            >
+              <Typography className={classes.sectionSubheading}>
+                Map Controls
+              </Typography>
+              <RhessysSection />
+              <RhessysOutputsSection />
+            </div>
+
+            <Divider className={classes.sectionDivider} />
+
+            <div
+              className={`${classes.sectionSubgroup} ${classes.sectionSubgroupLinks}`}
+            >
+              <Typography className={classes.sectionSubheading}>
+                Links and Reports
+              </Typography>
+              <Typography className={classes.linksHint}>
+                No external reports are currently available for this section.
+              </Typography>
+            </div>
           </Paper>
         )}
 

--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type KeyboardEvent } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useRunId } from "../../hooks/useRunId";
 import { useQuery } from "@tanstack/react-query";
@@ -100,7 +100,14 @@ const useStyles = tss.create(({ theme }) => ({
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
+    width: "100%",
+    textAlign: "left",
     cursor: "pointer",
+    backgroundColor: "transparent",
+    color: "inherit",
+    font: "inherit",
+    appearance: "none",
+    WebkitAppearance: "none",
     padding: theme.spacing(0.75, 1),
     border: "1px solid rgba(255, 255, 255, 0.2)",
     borderRadius: theme.shape.borderRadius,
@@ -206,6 +213,8 @@ function SkeletonWatershedPanel() {
     </div>
   );
 }
+
+const MILLCREEK_RUN_ID = "mdobre-invincible-scarab";
 
 export default function WatershedOverview() {
   const { classes } = useStyles();
@@ -372,19 +381,11 @@ export default function WatershedOverview() {
           >
             View WEPP interactive report
           </Link>
-          {runId === "mdobre-invincible-scarab" && (
+          {runId === MILLCREEK_RUN_ID && (
             <div className={classes.reportDropdownWrapper}>
-              <div
+              <button
                 className={classes.reportDropdownHeader}
                 onClick={() => setRxfireOpen((prev) => !prev)}
-                onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setRxfireOpen((prev: boolean) => !prev);
-                  }
-                }}
-                role="button"
-                tabIndex={0}
                 aria-expanded={rxfireOpen}
                 aria-controls="rxfire-links"
               >
@@ -396,9 +397,9 @@ export default function WatershedOverview() {
                 ) : (
                   <ExpandMoreIcon fontSize="small" />
                 )}
-              </div>
+              </button>
               <Collapse in={rxfireOpen}>
-                <div className={classes.reportDropdownLinks}>
+                <div id="rxfire-links" className={classes.reportDropdownLinks}>
                   <Link
                     href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Manager_Defined.html"
                     target="_blank"

--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useRunId } from "../../hooks/useRunId";
 import { useQuery } from "@tanstack/react-query";
@@ -16,6 +16,9 @@ import Paper from "@mui/material/Paper";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import DownloadIcon from "@mui/icons-material/Download";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import Collapse from "@mui/material/Collapse";
 import WeppSection from "./sections/WeppSection";
 import WatershedDataSection from "./sections/WatershedDataSection";
 import RhessysSection from "./sections/RhessysSection";
@@ -89,6 +92,29 @@ const useStyles = tss.create(({ theme }) => ({
     display: "flex",
     alignItems: "flex-start",
     justifyContent: "space-between",
+  },
+  reportDropdownWrapper: {
+    marginBottom: theme.spacing(1.5),
+  },
+  reportDropdownHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    cursor: "pointer",
+    padding: theme.spacing(0.75, 1),
+    border: "1px solid rgba(255, 255, 255, 0.2)",
+    borderRadius: theme.shape.borderRadius,
+    "&:hover": {
+      backgroundColor: "rgba(255, 255, 255, 0.06)",
+    },
+  },
+  reportDropdownLabel: {
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: 600,
+  },
+  reportDropdownLinks: {
+    paddingLeft: theme.spacing(1),
+    paddingTop: theme.spacing(0.75),
   },
 }));
 
@@ -186,6 +212,7 @@ export default function WatershedOverview() {
   const navigate = useNavigate();
 
   const runId = useRunId();
+  const [rxfireOpen, setRxfireOpen] = useState(false);
 
   // Lightweight data checks for the Long Term Impact visibility guard.
   // The sections themselves call the full hooks with useLayerQuery side-effects.
@@ -345,6 +372,56 @@ export default function WatershedOverview() {
           >
             View WEPP interactive report
           </Link>
+          {runId === "mdobre-invincible-scarab" && (
+            <div className={classes.reportDropdownWrapper}>
+              <div
+                className={classes.reportDropdownHeader}
+                onClick={() => setRxfireOpen((prev) => !prev)}
+                role="button"
+                aria-expanded={rxfireOpen}
+              >
+                <Typography className={classes.reportDropdownLabel}>
+                  Site Specific Prescribed Fire Scenarios
+                </Typography>
+                {rxfireOpen ? (
+                  <ExpandLessIcon fontSize="small" />
+                ) : (
+                  <ExpandMoreIcon fontSize="small" />
+                )}
+              </div>
+              <Collapse in={rxfireOpen}>
+                <div className={classes.reportDropdownLinks}>
+                  <Link
+                    href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Manager_Defined.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={classes.actionLink}
+                    underline="always"
+                  >
+                    Manager Defined
+                  </Link>
+                  <Link
+                    href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Stream_Order_2.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={classes.actionLink}
+                    underline="always"
+                  >
+                    Stream Order 2
+                  </Link>
+                  <Link
+                    href="https://wepp-in-the-woods.github.io/millcreek-rxfire-reports/MillCreek_RxFire_Report_Stream_Order_3.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={classes.actionLink}
+                    underline="always"
+                  >
+                    Stream Order 3
+                  </Link>
+                </div>
+              </Collapse>
+            </div>
+          )}
           <WeppSection />
         </Paper>
 

--- a/client/src/components/side-panels/WatershedOverview.tsx
+++ b/client/src/components/side-panels/WatershedOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type KeyboardEvent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useRunId } from "../../hooks/useRunId";
 import { useQuery } from "@tanstack/react-query";
@@ -377,8 +377,16 @@ export default function WatershedOverview() {
               <div
                 className={classes.reportDropdownHeader}
                 onClick={() => setRxfireOpen((prev) => !prev)}
+                onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setRxfireOpen((prev: boolean) => !prev);
+                  }
+                }}
                 role="button"
+                tabIndex={0}
                 aria-expanded={rxfireOpen}
+                aria-controls="rxfire-links"
               >
                 <Typography className={classes.reportDropdownLabel}>
                   Site Specific Prescribed Fire Scenarios

--- a/client/src/components/side-panels/sections/RhessysSection.tsx
+++ b/client/src/components/side-panels/sections/RhessysSection.tsx
@@ -23,6 +23,9 @@ const useStyles = tss.create(({ theme }) => ({
     "&:hover .MuiOutlinedInput-notchedOutline": {
       borderColor: theme.palette.primary.contrastText,
     },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: theme.palette.primary.contrastText,
+    },
     "& .MuiSvgIcon-root": {
       color: theme.palette.primary.contrastText,
     },

--- a/client/src/components/side-panels/sections/WeppSection.tsx
+++ b/client/src/components/side-panels/sections/WeppSection.tsx
@@ -47,9 +47,6 @@ const useStyles = tss.create(({ theme }) => ({
     },
   },
   scenarioGroup: {
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    padding: theme.spacing(1),
     marginBottom: theme.spacing(0.5),
   },
   scenarioSelect: {
@@ -63,9 +60,18 @@ const useStyles = tss.create(({ theme }) => ({
     "&:hover .MuiOutlinedInput-notchedOutline": {
       borderColor: theme.palette.primary.contrastText,
     },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: theme.palette.primary.contrastText,
+    },
     "& .MuiSvgIcon-root": {
       color: theme.palette.primary.contrastText,
     },
+  },
+  scenarioSelectPaper: {
+    maxHeight: 300,
+  },
+  scenarioFormControl: {
+    marginTop: theme.spacing(0.5),
   },
   scenarioLabel: {
     color: theme.palette.primary.contrastText,
@@ -175,7 +181,7 @@ export default function WeppSection() {
   return (
     <>
       <div className={classes.scenarioGroup}>
-        <FormControl fullWidth size="small" disabled={scenarioLoading}>
+        <FormControl fullWidth size="small" disabled={scenarioLoading} className={classes.scenarioFormControl}>
           <InputLabel
             id="scenario-select-label"
             className={classes.scenarioLabel}
@@ -199,6 +205,7 @@ export default function WeppSection() {
             label="Scenario"
             onChange={handleScenarioSelect}
             className={classes.scenarioSelect}
+            MenuProps={{ PaperProps: { className: classes.scenarioSelectPaper } }}
           >
             <MenuItem value="none">None</MenuItem>
             {availableScenarios.map((s) => (


### PR DESCRIPTION
This pull request adds a collapsible section for prescribed fire scenario reports (visible only for Mill Creek) and various UI refinements for the scenario selection dropdown. This is achieved with a conditional render in the watershed overview component - if more reports are to be added in the future for other watersheds, a different approach will be required. 

**Watershed Overview Panel Improvements:**

* Added a collapsible dropdown in `WatershedOverview.tsx` to display links to site-specific prescribed fire scenario reports, visible only when `runId` is `"mdobre-invincible-scarab"`. This includes new UI elements, state management with `useState`, and conditional rendering for enhanced user experience. [[1]](diffhunk://#diff-d45e3f8096097acccd3e1b45f4771fe6ece6315b06001e7f46cd9cd9ca48e55cL1-R1) [[2]](diffhunk://#diff-d45e3f8096097acccd3e1b45f4771fe6ece6315b06001e7f46cd9cd9ca48e55cR19-R21) [[3]](diffhunk://#diff-d45e3f8096097acccd3e1b45f4771fe6ece6315b06001e7f46cd9cd9ca48e55cR96-R118) [[4]](diffhunk://#diff-d45e3f8096097acccd3e1b45f4771fe6ece6315b06001e7f46cd9cd9ca48e55cR215) [[5]](diffhunk://#diff-d45e3f8096097acccd3e1b45f4771fe6ece6315b06001e7f46cd9cd9ca48e55cR375-R424)

**WEPP Section UI Enhancements:**

* Refined the scenario selection dropdown in `WeppSection.tsx` by:
  - Removing the border and padding from the scenario group for a cleaner look.
  - Improving the focus and hover styles for the dropdown, ensuring consistent contrast and accessibility.
  - Limiting the dropdown menu's maximum height and adding spacing to the form control for better usability. [[1]](diffhunk://#diff-31377827299f22824e5d97b4b33abb4f68517df3adc187114743c037962be9e7R63-R75) [[2]](diffhunk://#diff-31377827299f22824e5d97b4b33abb4f68517df3adc187114743c037962be9e7L178-R184) [[3]](diffhunk://#diff-31377827299f22824e5d97b4b33abb4f68517df3adc187114743c037962be9e7R208)…on styles