### PR TITLE
Add database backup and deployment design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ pgadmin-servers.json
 
 caddy_data/
 
+# Local production systems-administration records
+docs/sys-administration/
+
 # MacOS
 .DS_Store

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -119,17 +119,28 @@ tmux attach -t data-load
 
 ### Download Data Files (Optional)
 
-Pre-download data files to avoid repeated network fetches when reloading the database. Downloaded files are cached in the named Docker volume `watershed_data` (mounted at `/data` in the server container). The server Dockerfile creates `/data` and sets permissions so the loader can write files. You can pre-download from the container using the `download_data` management command.
+Pre-download data files to avoid repeated network fetches when initially loading
+an empty database. Downloaded files are cached in the named Docker volume
+`watershed_data` (mounted at `/data` in the server container). The current
+command skips every existing filename without checking a source revision or
+checksum; remove or replace stale cache entries only under an approved runbook.
 
 ```bash
 # Download ALL production data (recommended for production)
 docker compose -f compose.prod.yml exec server python manage.py download_data --all
-
-# Or download specific watersheds by runid
-docker compose -f compose.prod.yml exec server python manage.py download_data --runids <runid1> <runid2>
 ```
 
+Do not use `download_data --runids` for the NASA batch in the current
+implementation. Its custom master filename is incorrectly treated as the batch
+identifier, so matching NASA run IDs are silently skipped. Use `--all` under an
+approved initial-load runbook until the filter is corrected and regression
+tested.
+
 ### Load Data into Database
+
+The commands below are legacy initial-load tools for an empty database. They do
+not reconcile a populated production database and must not be used as a routine
+update procedure.
 
 ```bash
 # Load ALL watersheds (production - discovers all from API)
@@ -141,16 +152,13 @@ docker compose -f compose.prod.yml exec server python manage.py load_watershed_d
 # Load development subset only (defaults if no args provided - testing only)
 docker compose -f compose.prod.yml exec server python manage.py load_watershed_data
 
-# Preview what would be loaded (safe to test)
+# Print the selected configuration only; this does not fetch or validate data
 docker compose -f compose.prod.yml exec server python manage.py load_watershed_data --dry-run
-
-# Force reload even if data already exists
-docker compose -f compose.prod.yml exec server python manage.py load_watershed_data --force --all
 ```
 
 ### Complete Data Setup (Download + Load)
 
-For initial deployment or major data updates:
+For an initial empty-database load only:
 
 ```bash
 # 1. (Optional) Pre-download all production data files to avoid network fetches
@@ -160,29 +168,27 @@ docker compose -f compose.prod.yml exec server python manage.py download_data --
 docker compose -f compose.prod.yml exec server python manage.py load_watershed_data --all
 ```
 
-**Note:** The download step is optional — the loader will fetch from remote URLs if cached files aren't available. Pre-downloading can be faster for subsequent reloads.
+**Note:** The download step is optional—the loader will fetch from remote URLs
+if cached files are unavailable. This workflow is not safe for updating a
+populated production database.
 
 ### Major Schema or Data Source Updates
 
-When updating data sources or making significant schema changes, you may need to fully reset and reload the data:
+Do not use `docker compose down` or `load_watershed_data --force` as a routine
+production data-update procedure. PostgreSQL currently uses an anonymous
+volume, and the loader deletes all watershed rows before replacement loading;
+a failure or partial source load can therefore leave production empty or
+incomplete.
 
-```bash
-# 1. Stop services and remove containers (⚠️ this WIPES the database - see note below)
-docker compose -f compose.prod.yml down
-
-# 2. Re-run the deploy action from GitHub Actions UI to rebuild containers
-
-# 3. After deployment completes, reload all watershed data
-tmux new -s data-load
-docker compose -f compose.prod.yml exec server python manage.py load_watershed_data --force --all
-```
-
-> ⚠️ **Important:** The database currently has NO persistent volume configured. Running `docker compose down` removes the database container and **all data is lost**. This is acceptable while only loading watershed data, but a persistent volume must be added before storing user data.
-
-> **Future Consideration:** Before adding user data:
-> 1. Add a named volume for PostgreSQL data persistence in `compose.prod.yml`
-> 2. Implement migration strategies that preserve user data while updating watershed/geospatial data
-> 3. Consider separating user data into distinct tables with foreign key relationships that can survive watershed data reloads
+The proposed reproducible release, reconciliation, validation, and rollback
+workflow is specified in
+[docs/database-deployment-architecture.md](docs/database-deployment-architecture.md).
+Until that tooling is implemented, every production data-source change requires
+an individually reviewed runbook, a newly verified off-host backup, validation
+in an isolated database, explicit expected additions/removals/counts, and
+post-change API verification. Adding a named volume also requires a controlled
+backup/restore cutover; merely adding the Compose mount would start an empty
+database.
 
 ## Useful Commands
 
@@ -193,8 +199,8 @@ docker compose -f compose.prod.yml logs -f [service_name]
 # Check service status
 docker compose -f compose.prod.yml ps
 
-# Stop all services
-docker compose -f compose.prod.yml down
+# Stop services without removing containers or losing the database reference
+docker compose -f compose.prod.yml stop
 
 # Start services
 docker compose -f compose.prod.yml up -d

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ The application is deployed on a managed virtual machine provided by the [Univer
 
 For more deployment information, see [DEPLOYMENT.md](./DEPLOYMENT.md).
 
+The authoritative list of production watershed datasets, run migrations, and
+RHESSys availability is maintained in
+[docs/database-inventory.md](./docs/database-inventory.md).
+The proposed reproducible build and deployment design is documented in
+[docs/database-deployment-architecture.md](./docs/database-deployment-architecture.md).
+Its independent review findings and dispositions are recorded in
+[docs/database-deployment-architecture-review.md](./docs/database-deployment-architecture-review.md).
+
 ## Development Setup
 This section guides developers on how to set up, configure, and run the application locally using Docker and VSCode Dev Containers.
 
@@ -140,6 +148,10 @@ docker compose exec server python manage.py download_data --runids <runid1> <run
 docker compose exec server python manage.py download_data --all
 ```
 
+Known limitation: filtered download currently skips NASA runs because that
+batch uses a custom master filename. Use `--all` when the NASA files are needed
+until the filter is fixed and regression tested.
+
 #### Loading Watershed Data
 
 ```bash
@@ -152,7 +164,7 @@ docker compose exec server python manage.py load_watershed_data --runids <runid1
 # Load ALL watersheds (discovers all available from API)
 docker compose exec server python manage.py load_watershed_data --all
 
-# Preview what would be loaded (safe to test)
+# Preview selected configuration only (does not fetch or validate source data)
 docker compose exec server python manage.py load_watershed_data --dry-run
 
 # Force reload data (clears existing data first)

--- a/docs/database-deployment-architecture-review.md
+++ b/docs/database-deployment-architecture-review.md
@@ -1,0 +1,89 @@
+# Database Deployment Architecture Review Disposition
+
+Review date: 2026-07-16
+
+Reviewed document:
+[Database Deployment Architecture and Tooling Specification](database-deployment-architecture.md)
+
+An independent review cross-checked the proposed architecture against the
+current Compose configuration, GitHub deployment workflow, production
+entrypoint, watershed loader, download cache, writers, inventory, API identity
+behavior, and deployment documentation.
+
+The initial review produced 18 findings. A closure pass found four incomplete
+dispositions and one new contradiction. All initial and closure findings were
+accepted and incorporated into the specification or related safety
+documentation. No finding was rejected or dismissed as prose-only. “Accepted”
+here means the requirement is now part of the design; it does not mean the
+corresponding production implementation has already occurred.
+
+## High-severity findings
+
+| ID | Finding | Disposition |
+| --- | --- | --- |
+| H1 | `dataset_key` ambiguously represented both a collection and an individual watershed. | Accepted. The spec now requires distinct immutable `collection_key` and `watershed_key` values, replaceable run IDs, and explicit split/merge/replacement lineage. Manifest schema work is blocked until this distinction is implemented. |
+| H2 | A single tracked plan could not represent production upgrade, rollback, staging, and empty-build bases. | Accepted. Target manifests no longer contain an intrinsic plan. Forward, exact inverse, and empty-build plans are separately keyed by base, target, contract, materializer, and fingerprint versions. |
+| H3 | A PostgreSQL session advisory lock could not span the proposed separate command processes. | Accepted. The host orchestrator owns a durable attempt lease; activation locks the singleton active-release row, reasserts the base, recomputes the plan, and takes a transaction advisory lock. The legacy loader must be production-gated. |
+| H4 | Code/schema deployment could race data deployment. | Accepted. Both workflows must share one GitHub concurrency group, canonical host lock, Compose project, and compatibility checks. Migrations become an explicit one-shot deployment step. |
+| H5 | Adding a named PostgreSQL volume without migrating the anonymous volume would start an empty database. | Accepted. Phase 0 now requires a pinned-version, off-host-backed-up, quiesced restore/cutover runbook that retains the old volume through acceptance. |
+| H6 | The staging representation was unspecified. | Accepted. Version 1 uses fixed, logged, migration-created, attempt-scoped staging tables with bounded-memory loading, constraints, space preflight, leases, and recovery cleanup. |
+| H7 | Root-level release files are unavailable in the current server image. | Accepted. Production tooling runs from a one-off code/toolchain-only release-tool image built from the repository root and pinned by digest. Manifests and plans are excluded from the image and mounted read-only or fetched by verified hash. |
+| H8 | Wildcard deletion authorization contradicted exact desired state. | Accepted. Globs are prohibited. Every removal is an exact reviewed run ID or a hashed exact set derived from an identified base collection. |
+| H9 | RHESSys declarations had no atomically activated runtime representation. | Accepted. The spec now requires serving capability rows containing mode, durable base URI, immutable index, and runtime configuration, activated with watershed rows. The inventory also marks current WEPPcloud locations as observed state pending durable copying. |
+
+## Medium-severity findings
+
+| ID | Finding | Disposition |
+| --- | --- | --- |
+| M1 | Attempts abandoned outside `applying` had no recovery semantics. | Accepted. Attempts have owner, heartbeat, and expiry fields; `data_release recover` terminalizes expired attempts and cleans staging. A singleton `ActiveDataRelease` provides one lockable state row, initially `EMPTY` and later `ACTIVE`. |
+| M2 | Replacing child rows would change public GeoJSON feature IDs. | Accepted. Reconciliation must upsert retained business identities in place and preserve primary keys, or a compatible stable-feature-ID API migration must occur first. |
+| M3 | Child identity and Parquet join semantics disagreed. | Accepted. Data-contract version 1 defines subcatchment identity and Parquet cardinality on `(watershed, topazid)`. A production audit found no duplicate `topazid` within a watershed. Other keys require a new contract. |
+| M4 | Idempotency included unavoidable audit writes and was required before reconciliation existed. | Accepted. Idempotency is now defined over domain, capability, active-pointer, and artifact state; audit attempts may append. Repeat-apply proof moved to the reconciliation phase. |
+| M5 | Compatibility specified only a minimum migration. | Accepted. Releases now lock schema signature or bounded migrations, data-contract range, code/toolchain-only materializer image digest and Git revision, fingerprint algorithm, and output-affecting toolchain versions. The image digest is resolved before manifests and plans are generated. |
+| M6 | Rollback was not a preapproved executable workflow. | Accepted. CI generates an exact inverse plan, artifacts are retained, and a dedicated rollback command asserts the currently active failed target. |
+| M7 | Backup durability, RPO, and retention were left as optional decisions. | Accepted. Destructive operations require verified encrypted off-host backups. Scheduled off-host backup with a 24-hour default RPO is a Phase 0 requirement now, and retention covers the active plus two rollback releases. |
+| M8 | Related documentation still recommended unsafe reset behavior and overstated current loader coverage. | Accepted. `DEPLOYMENT.md` no longer recommends `down` plus forced reload or the broken NASA filtered-download path, and the inventory distinguishes observed loader configuration from approved target state and rejects current `--dry-run` as validation. |
+| M9 | Production database exposure and temporary secret-file handling were omitted. | Accepted. Phase 0 now requires removing or loopback-binding the database host port and using mode-`0600`, minimized, reliably cleaned environment files. |
+
+## Closure-pass findings
+
+| ID | Finding | Disposition |
+| --- | --- | --- |
+| C1 | Embedding digest-bearing manifests and plans in the materializer image made its digest self-referential. | Accepted. The image contains code and toolchain only. Its digest is resolved first; manifests and plans reference it and are supplied separately by verified hash. |
+| C2 | An empty build had no active-release row to lock. | Accepted. The ledger migration creates one lockable singleton in explicit `EMPTY` state with a nullable release pointer; first activation transitions it to `ACTIVE`. |
+| C3 | The inventory still treated TTL-managed WEPPcloud RHESSys paths as accepted target hosting. | Accepted. Those paths are now labeled observed current state, and all accepted capabilities require verified durable project copies and immutable indexes before activation. |
+| C4 | Production documentation still advertised `download_data --runids`, which silently skips NASA because of its custom master filename. | Accepted. The production command was removed and the limitation is documented until code and regression tests fix it. |
+| C5 | Scheduled backups remained conditional even though non-watershed tables are already persistent by design. | Accepted. Scheduled encrypted off-host backup with a 24-hour default RPO is required in Phase 0 now. |
+
+## Defaults adopted from review
+
+- Project-controlled encrypted S3-compatible artifact storage with versioning
+  or object lock, content-addressed keys, and no TTL for retained releases.
+- All non-watershed Django tables are persistent by default.
+- Mandatory stable watershed keys are introduced before release schema
+  implementation.
+- Reviewed hashed batch-member indexes are authoritative.
+- Metadata authority is defined field by field and unresolved conflicts fail.
+- Accepted RHESSys assets move out of TTL-managed storage.
+- Production release deployment remains manual and independently approved.
+- The active release plus two rollback releases and their supporting artifacts,
+  plans, reports, and backups are retained.
+- The pinned release-tool image digest is the reproducibility boundary.
+
+## Verification performed during disposition
+
+A read-only query of production on 2026-07-16 confirmed:
+
+- zero duplicated `(watershed_id, topazid)` subcatchment identities; and
+- zero duplicated `(watershed_id, topazid, weppid)` subcatchment identities.
+
+This supports the proposed version-1 Parquet join contract but does not replace
+validation of every future release artifact.
+
+## Remaining implementation status
+
+The architecture and documentation findings are dispositioned. Production
+changes—including volume migration, network hardening, release schemas,
+staging tables, ledger models, capability serving rows, workflow serialization,
+and the deploy tool—remain future implementation work and must follow the
+phased plan in the specification.

--- a/docs/database-deployment-architecture.md
+++ b/docs/database-deployment-architecture.md
@@ -1,0 +1,1207 @@
+# Database Deployment Architecture and Tooling Specification
+
+Status: Proposed
+
+Last updated: 2026-07-16
+
+Related documents:
+
+- [Production database and data-source inventory](database-inventory.md)
+- [Independent review disposition](database-deployment-architecture-review.md)
+- [Deployment guide](../DEPLOYMENT.md)
+
+## 1. Summary
+
+Watershed data should be deployed as a versioned declaration of desired state,
+not as a sequence of production patches and not by discovering mutable upstream
+state during deployment.
+
+Each data release will lock:
+
+- the exact watershed run IDs that should exist;
+- immutable source artifacts and their checksums;
+- deterministic enrichment or conversion lineage;
+- expected database record counts and validation rules;
+- declared RHESSys capabilities and required external assets; and
+- the code and database-schema contract needed to materialize the release.
+
+A strict release tool will prepare and validate all data before modifying the
+serving tables. It will then reconcile the watershed-owned tables in one atomic
+operation. Applying the same release again must produce no changes. The same
+release must also be capable of building the watershed tables in an empty
+database.
+
+The production PostgreSQL volume should be named and persistent even though the
+watershed dataset is reconstructible. Replaceability must be an explicit,
+tested property of the build process rather than an accidental consequence of
+an anonymous Docker volume.
+
+## 2. Motivation and current limitations
+
+The current deployment has useful components, but they do not form a database
+build system:
+
+- the GitHub deployment workflow rebuilds the application and runs Django
+  migrations, but it does not deploy watershed data;
+- `load_watershed_data` refuses to run against a populated database unless
+  `--force` is supplied;
+- `--force` deletes all watershed data in a transaction that commits before
+  the replacement load starts;
+- batch and child records are inserted rather than reconciled;
+- individual source failures can be logged and ignored, allowing a partial
+  load to commit;
+- `--dry-run` does not fetch, parse, compare, or validate input data;
+- downloaded files are considered current whenever a matching filename
+  exists, with no checksum or source-version validation;
+- production deployment does not record which source revisions produced the
+  active rows; and
+- PostgreSQL uses an anonymous Docker volume while the data cache uses a named
+  volume.
+
+These behaviors cannot reliably support deletion, metadata correction, batch
+replacement, repeated deployment, or recovery from a partially failed load.
+
+## 3. Goals
+
+The proposed system must:
+
+1. Materialize the same watershed state from the same release inputs every
+   time.
+2. Build from an empty database and reconcile an existing database using the
+   same release definition.
+3. Represent additions, updates, replacements, and removals explicitly.
+4. Validate every required input before changing serving data.
+5. Fail the release when any required watershed or artifact fails.
+6. Preserve the previously active watershed state when a release fails.
+7. Produce a reviewable plan before applying destructive changes.
+8. Record artifact lineage, release identity, counts, code revision, and
+   validation results.
+9. Separate schema evolution from data-state evolution while checking their
+   compatibility.
+10. Make external RHESSys availability explicit rather than inferring it from
+    the existence of a PostgreSQL watershed row.
+11. Support rollback to the previous accepted data release.
+12. Work without storing large GeoJSON, Parquet, or GeoTIFF files in Git.
+
+## 4. Non-goals
+
+The first implementation will not:
+
+- use PostgreSQL as the durable archive for RHESSys source files;
+- replay a growing history of one-off data patches to construct current state;
+- deploy directly from a mutable upstream batch response;
+- silently accept unavailable optional data when the release declares it
+  required;
+- make all application deployments automatically perform a data deployment;
+  or
+- initially require blue-green replacement of the entire PostgreSQL cluster.
+
+Blue-green database deployment remains a possible later optimization. The
+initial reconciler is designed to preserve Django authentication and other
+non-watershed tables while still proving that watershed data can be rebuilt
+from nothing.
+
+## 5. Terminology
+
+| Term | Meaning |
+| --- | --- |
+| Data release | An immutable declaration of the complete desired watershed inventory and its locked inputs. |
+| Release manifest | The reviewed, tracked release file containing intent, exact dataset membership, validation policy, and artifact references. |
+| Artifact | A GeoJSON, Parquet, GeoTIFF, or index file identified by content checksum and stored outside Git. |
+| Preparation | Resolving upstream sources, transforming or enriching data, publishing immutable artifacts, and generating a release plan. |
+| Build | Materializing a data release into empty watershed tables. |
+| Reconciliation | Converging existing watershed tables to exactly match a data release. |
+| Deployment | Backup, preflight, reconciliation, validation, activation, and reporting. |
+| Collection key | A stable project-controlled identity for one source grouping, such as a batch or standalone source definition. |
+| Watershed key | A mandatory stable project-controlled identity for exactly one logical watershed, distinct from its collection and replaceable upstream run ID. |
+| Run ID | The current source-specific WEPPcloud identifier and source revision. It is also the existing database primary key and public route identifier. |
+| Capability | A declared optional product family, such as RHESSys dynamic Parquets or precomputed map GeoTIFFs. |
+
+## 6. Architectural principles
+
+### 6.1 Desired state, not patch history
+
+The active release contains the complete set of desired datasets. A run absent
+from that set is a deletion candidate. A metadata or geometry change appears as
+a changed artifact fingerprint. A replacement appears as one removed run and
+one added run, with optional lineage metadata describing the relationship.
+
+Database patches are reserved for:
+
+- Django schema migrations;
+- migrations of persistent, non-derived application state; and
+- emergency corrections that are immediately incorporated back into the
+  manifest or source artifact.
+
+A manual database correction that is not represented in the release will be
+lost on the next reconciliation and is therefore not an accepted steady state.
+
+Idempotency applies to watershed-domain rows, capability serving rows, the
+active-release pointer, and immutable artifacts: applying an already active
+release changes none of them. Audit attempts, heartbeats, logs, and reports may
+be appended and are excluded from the domain fingerprint.
+
+### 6.2 Resolve upstream state before deployment
+
+Preparation may inspect a WEPPcloud batch, enrich a master GeoJSON, and generate
+an exact member index. Deployment consumes only the locked results of that
+preparation.
+
+This separation prevents an upstream removal, TTL deletion, schema change, or
+temporary empty response from becoming an unintended production deletion.
+
+### 6.3 Immutable and content-addressed inputs
+
+Every required artifact must have a SHA-256 checksum and expected byte size.
+Mutable URLs are permitted only as preparation inputs. Deployment artifacts
+must be immutable or copied to a durable project-controlled location before
+the release is accepted.
+
+The local cache will be keyed by checksum, for example:
+
+```text
+/data/artifacts/sha256/be/be152890a843.../
+```
+
+Filename existence alone will never establish cache validity.
+
+### 6.4 Strict before atomic
+
+Network access, checksums, parsing, joins, schema checks, geometry checks, and
+record construction occur before serving rows are changed. Reconciliation then
+runs under a database advisory lock and a single transaction. Required source
+errors are fatal.
+
+### 6.5 Replaceable data, persistent service
+
+The watershed tables are derived and must be clean-buildable. The serving
+PostgreSQL instance should nevertheless use a named volume so routine container
+lifecycle events cannot discard it. Rebuilds and cutovers must be explicit
+operations with validation and rollback.
+
+## 7. System overview
+
+```text
+ Mutable upstream sources                 Git repository
+ (WEPPcloud, enrichment files)            (release manifest + code)
+              |                                      |
+              v                                      v
+      release preparation -----------------> reviewable plan/diff
+              |
+              v
+ Durable immutable artifact store
+ (GeoJSON, Parquet, GeoTIFF, indexes)
+              |
+              v
+     checksum-verified local cache
+              |
+              v
+       staging + full validation
+              |
+              v
+   atomic watershed reconciliation ------> build ledger/report
+              |
+              v
+       serving PostGIS database ----------> Django API
+```
+
+RHESSys files remain outside PostgreSQL. The release declares where they live,
+what products are supported, and what must be validated before a capability is
+advertised by the application.
+
+## 8. Release representation
+
+### 8.1 Repository layout
+
+The proposed tracked layout is:
+
+```text
+data-releases/
+  schema/
+    release-manifest.schema.json
+    batch-index.schema.json
+    rhessys-index.schema.json
+  releases/
+    2026-07-16.1/
+      release.yaml
+      batch-members.json
+  plans/
+    BASE_SHA--TARGET_SHA/
+      MATERIALIZER_DIGEST/
+        forward.json
+        rollback.json
+        empty-build.json
+```
+
+Large source artifacts are stored in durable object storage, not in this
+directory. Tracked indexes remain small enough for code review.
+
+### 8.2 Release manifest
+
+The exact schema will be formalized in JSON Schema. A representative structure
+is:
+
+```yaml
+schema_version: 1
+release_id: 2026-07-16.1
+created_at: 2026-07-16T23:00:00Z
+
+compatibility:
+  data_contract: 1
+  schema_signature: "..."
+  supported_migrations:
+    minimum: watershed.0006_watershed_utility_metadata
+    maximum: watershed.0006_watershed_utility_metadata
+  materializer:
+    image_digest: sha256:...
+    git_commit: "..."
+    fingerprint_algorithm: 1
+  toolchain:
+    postgres: "..."
+    postgis: "..."
+    gdal: "..."
+
+collections:
+  - collection_key: gate-creek
+    display_name: Gate Creek
+    source:
+      kind: standalone
+      project_path: disturbed9002_wbt
+    member:
+      watershed_key: gate-creek
+      runid: aversive-forestry
+    boundary:
+      uri: https://artifacts.example/.../bound.geojson
+      sha256: "..."
+      bytes: 12345
+    per_run_index:
+      uri: https://artifacts.example/.../gate-creek-index.json
+      sha256: "..."
+    expected:
+      watersheds: 1
+      subcatchments: 123
+      channels: 45
+    rhessys:
+      mode: dynamic
+      index_uri: https://artifacts.example/.../rhessys-index.json
+      index_sha256: "..."
+
+  - collection_key: nasa-roses-202606-psbs
+    display_name: NASA ROSES 202606 PSBS
+    source:
+      kind: batch
+      batch_id: nasa-roses-202606-psbs
+    master_geojson:
+      uri: https://artifacts.example/.../resources.enriched.geojson
+      sha256: "..."
+      bytes: 12345678
+    member_index:
+      path: batch-members.json
+      sha256: "..."
+    lineage:
+      replaces: nasa-roses-2026-sbs
+      transformation: nasa_wws_enrichment_v1
+```
+
+The real manifest must contain only exact artifact locations and hashes. Every
+member, including every batch member, must have a mandatory `watershed_key`.
+The example URI, signatures, versions, and counts above are illustrative.
+
+### 8.3 Base-specific deployment plans
+
+A release manifest describes only target state. A deployment plan is derived
+from a particular base state and is not intrinsic to the target release.
+
+Plans are stored and reviewed separately, keyed by at least:
+
+- base manifest SHA-256, or an explicit empty base;
+- target manifest SHA-256;
+- data-contract version;
+- materializer image digest; and
+- fingerprint-algorithm version.
+
+CI should produce three plans where applicable:
+
+- a forward production plan from the expected active release;
+- an exact inverse rollback plan from the target back to that base; and
+- an empty-build plan used to prove reconstruction.
+
+Every plan contains exact added, removed, and changed run IDs. Destructive
+authorization cannot use globs. A large collection replacement may reference a
+hashed exact removal-set artifact derived from the reviewed base manifest. The
+apply transaction must assert that the active base release matches the plan;
+otherwise it refuses to mutate the database.
+
+### 8.4 Exact batch membership
+
+A batch release must lock the exact desired member run IDs. Deployment must
+not rediscover them from the batch API.
+
+Small batches may list members directly. Large batches should reference a
+tracked or immutable batch index containing, for every member:
+
+- canonical run ID;
+- mandatory stable `watershed_key`;
+- expected display metadata;
+- boundary, subcatchment, channel, hillslope, soil, and land-use artifact
+  references;
+- independent hashes for metadata, geometry, and child datasets; and
+- expected counts and geometry bounds.
+
+Explicit membership gives watershed removal reviewable semantics. A preparation
+report must show added, removed, retained, and changed members relative to the
+currently active release.
+
+### 8.5 Transformation and enrichment lineage
+
+Deployment should consume the final transformed artifact rather than perform a
+join against a mutable enrichment URL. The release records:
+
+- every source artifact hash;
+- transformation name and version;
+- transformation code Git commit;
+- configuration and join keys;
+- output artifact hash;
+- matched, unmatched, and duplicate counts; and
+- validation report hash.
+
+For the NASA successor batch, the new batch's run IDs and geometries remain
+authoritative while approved metadata is joined from the WWS source. Historical
+source run IDs must never overwrite successor run IDs.
+
+### 8.6 RHESSys representation
+
+RHESSys capability must be declared per mandatory watershed key and exact run
+ID. The RHESSys index should describe:
+
+- mode: `dynamic`, `precomputed`, or both;
+- durable base URI;
+- required scenarios;
+- required geometry revisions;
+- Parquet paths, schemas, spatial ID fields, variables, units, and year range;
+- GeoTIFF paths, checksums, CRS, bounds, dimensions, band count, and nodata
+  value;
+- required spatial-input files; and
+- whether each asset is required for release activation or optional.
+
+The capability declaration must be materialized as serving database state in
+the same activation transaction as the watershed rows. The application reads
+the declared mode, durable base URI, index URI and hash, scenarios, and geometry
+revisions from that state instead of hard-coded run ID sets or derived URL
+conventions. Runtime probing may remain as a health check, but it does not
+define intended capability.
+
+### 8.7 Secrets
+
+Manifests contain secret references, never credentials. For example:
+
+```yaml
+authentication:
+  secret_ref: WEPPCLOUD_NASA_202606_TOKEN
+```
+
+The deployment environment resolves the reference. Tokens must not appear in
+release plans, build reports, command lines, or database rows.
+
+## 9. Database representation
+
+### 9.1 Existing domain tables
+
+The first implementation will continue to materialize:
+
+- `watershed_watershed`;
+- `watershed_subcatchment`; and
+- `watershed_channel`.
+
+It will also materialize a `RunCapability` model keyed by watershed and
+capability type. A capability row contains the active mode, durable base URI,
+immutable index URI and checksum, and the runtime configuration needed by the
+API. RHESSys capability rows are replaced atomically with their corresponding
+watershed release state. A fingerprint without serving configuration is not
+sufficient.
+
+Soil, land-use, and hillslope properties remain denormalized onto
+`watershed_subcatchment` unless a separate schema change is approved.
+
+Only these explicitly declared watershed-domain and capability tables are
+owned by data reconciliation. Every other Django table is persistent by
+default. Before any non-owned table is allowed to reference a reconciled row,
+its stable identity, deletion behavior, and rollback semantics must be
+specified; a data release must not cascade-delete user-owned state.
+
+### 9.2 Release ledger
+
+A Django migration should introduce a small release ledger. Proposed records:
+
+#### `DataRelease`
+
+- `release_id`, unique;
+- manifest SHA-256;
+- release schema version;
+- data contract version;
+- status: `validated`, `active`, or `superseded`;
+- previous active release ID;
+- aggregate expected and actual counts; and
+- validation summary.
+
+#### `ActiveDataRelease`
+
+- a singleton row created by migration with state `EMPTY` and a nullable
+  `DataRelease` pointer;
+- state `ACTIVE` requires a non-null release pointer, while `EMPTY` is permitted
+  only before the first activation or in an intentional clean-build database;
+- active manifest hash and data-contract version; and
+- activation timestamp.
+
+The singleton constraint and a row lock provide the authoritative base-state
+assertion during activation.
+
+#### `DataReleaseAttempt`
+
+- release and previous active release;
+- application Git commit;
+- operator or workflow run identity;
+- status: `planning`, `staging`, `applying`, `succeeded`, `failed`, or
+  `rolled_back`;
+- started, validated, applied, and completed timestamps;
+- reviewed and actual plan hashes;
+- lease owner, heartbeat, and expiry timestamps;
+- backup artifact identity;
+- failure phase and sanitized error summary; and
+- deployment report location or hash.
+
+#### `DataRunState`
+
+- release, collection key, and mandatory watershed key;
+- canonical run ID;
+- metadata fingerprint;
+- watershed geometry fingerprint;
+- subcatchment, channel, and Parquet input fingerprints;
+- actual row counts;
+- RHESSys capability fingerprint; and
+- validation status.
+
+The ledger is an audit and optimization aid, not the source of truth. The
+tracked release manifest remains authoritative.
+
+During the design and bootstrap phases, `docs/database-inventory.md` remains
+the human-approved source of inventory decisions. Once Phase 1 is operational,
+the accepted release manifest becomes the executable authority and the
+inventory document should be generated from it or checked against it in CI.
+
+Fingerprint canonicalization must be specified and versioned. It should sort
+records by stable identity, normalize scalar and null representations, encode
+geometry in a defined CRS and binary form, and exclude database IDs, timestamps,
+and other volatile values. A fingerprint-algorithm change is itself a data
+contract change.
+
+### 9.3 Integrity constraints
+
+The reconciler should be supported by database constraints for identities that
+are already assumed by the loader:
+
+- one watershed per `runid`;
+- one subcatchment per `(watershed_id, topazid)` for data-contract version 1;
+- one channel per `(watershed_id, topazid, weppid, order)`.
+
+Constraint introduction requires a duplicate audit and an explicit Django
+migration. A read-only production audit on 2026-07-16 found no duplicate
+`topazid` values within a watershed. Because current Parquet enrichment joins
+on `topazid`, every release must enforce exactly one matching subcatchment and
+at most one authoritative Parquet row per `(watershed, topazid)`. A future
+artifact that needs a different business key requires a new data contract and
+join implementation rather than an implicit fallback.
+
+### 9.4 Stable logical identity
+
+The existing public identity is the source run ID. Replacing a WEPPcloud run
+therefore changes database primary keys, API URLs, bookmarks, and any future
+foreign keys.
+
+Every release member must have a stable `watershed_key`; every batch or
+standalone source grouping has a separate `collection_key`. The model should
+introduce `watershed_key` as a unique project-owned identity and treat upstream
+run IDs as replaceable source revisions and compatibility aliases. Public-route
+migration and redirects may be staged, but the identity must not remain
+optional in the release schema.
+
+Cases that need an explicit identity decision include:
+
+- Mill Creek moving from `mdobre-invincible-scarab` to `some-oligopoly`;
+- a batch member moving to another batch without changing watershed identity;
+- one watershed splitting into multiple features; and
+- multiple utilities sharing the same HUC10 geometry.
+
+Replacement lineage is represented explicitly between watershed keys and
+source revisions. Split and merge events list all predecessor and successor
+watershed keys and require a reviewed routing and foreign-key migration plan.
+
+## 10. Change semantics
+
+| Change | Release representation | Reconciliation behavior |
+| --- | --- | --- |
+| Add a watershed | Add exact member and artifacts | Insert watershed and children after validation. |
+| Remove a watershed | Omit member and declare expected removal | Delete children and watershed in the activation transaction. |
+| Correct metadata | New master artifact or metadata fingerprint | Update only authoritative metadata fields. |
+| Change watershed geometry | New geometry fingerprint | Update watershed geometry and regenerate simplified geometry. |
+| Change subcatchments or channels | New child fingerprint | Upsert retained business identities, insert additions, and delete true removals while preserving public feature IDs. |
+| Change soil, land use, or hillslope data | New Parquet fingerprint | Reapply mapped fields for that run, including authoritative nulls. |
+| Add a batch | Add batch and exact member index | Insert validated members; no runtime discovery. |
+| Replace a batch | Add successor and remove predecessor with lineage | Apply as reviewed additions/removals. |
+| Replace a standalone run | Change source revision for stable watershed key | Insert the new revision and retire the old run ID while preserving logical lineage. |
+| Add RHESSys data | Add capability and immutable asset index | Validate assets, then advertise capability. No PostgreSQL raster load. |
+| Remove RHESSys data | Remove capability with expected change | Stop advertising it; retain or garbage-collect assets per policy. |
+| Change model/schema | Django migration plus contract version | Deployment refuses incompatible code, schema, or data releases. |
+| Emergency manual correction | Temporary audited patch plus immediate release-source correction | Next reconciliation enforces the corrected desired state. |
+
+Metadata semantics must distinguish an absent property from an explicit null.
+For fields declared authoritative by a release schema, absence is a validation
+error; an explicit null clears the field. This prevents accidental retention of
+stale metadata.
+
+## 11. Supported and anticipated cases
+
+### 11.1 Known near-term changes
+
+The design must support the following already identified work:
+
+- replace Mill Creek `mdobre-invincible-scarab` with `some-oligopoly`;
+- re-vendor and validate Mill Creek RHESSys products;
+- retain Gate Creek `aversive-forestry` and its dynamic RHESSys products;
+- retain the Victoria batch while declaring RHESSys only for verified members;
+- replace `nasa-roses-2026-sbs` with `nasa-roses-202606-psbs`;
+- deterministically enrich the NASA successor resources GeoJSON;
+- remove selected watersheds from a batch;
+- update watershed metadata without changing geometry or child records;
+- add `bremerton-2026-psbs`; and
+- add future batches and RHESSys products.
+
+### 11.2 Additional cases
+
+| Category | Cases the tooling must handle or reject safely |
+| --- | --- |
+| Upstream lifecycle | Run deleted by TTL, source temporarily unavailable, batch returns zero members, path changes, mutable file changes without a new name. |
+| Identity | Run renamed, member moves between batches, duplicate run ID, case-only run ID change, logical watershed split or merge. |
+| Metadata | Field added or renamed, value becomes null, duplicate enrichment key, unmatched enrichment row, conflicting sources, string exceeds model width. |
+| Geometry | Invalid polygon, CRS missing or wrong, Polygon/MultiPolygon difference, empty geometry, large bounds shift, topology simplification change. |
+| Children | Duplicate TOPAZ identities, child references unknown watershed, subcatchment count collapses unexpectedly, Parquet key has no matching subcatchment. |
+| RHESSys | Scenario added or removed, variable renamed, Parquet schema changes, GeoTIFF CRS changes, geometry revision changes, only some assets upload successfully. |
+| Deployment | Retry after interruption, concurrent deploy, disk exhaustion, long transaction, application traffic during activation, post-activation smoke-test failure. |
+| Compatibility | New data requires code not deployed yet, code rollback cannot read new schema, migration changes field meaning, transform code changes with identical source bytes. |
+| Operations | Restore from backup, redeploy previous release, cache garbage collection, credential expiration, artifact-store outage, checksum mismatch. |
+| Persistent state | Django users, sessions, admin logs, or future user-created records must survive watershed rebuilds and may reference stable watershed identities. |
+| Reproducibility | GDAL, PostGIS, or transformation-library version changes output; timestamps or unordered iteration make artifacts nondeterministic. |
+
+Unexpected large differences must fail closed. They must never be interpreted as
+normal batch evolution merely because the upstream request succeeded.
+
+## 12. Preparation workflow
+
+Preparation converts mutable upstream information into a reviewable immutable
+release.
+
+A proposed operator interface is:
+
+```bash
+python manage.py data_release prepare \
+  --base data-releases/releases/CURRENT/release.yaml \
+  --descriptor data-releases/drafts/NEXT.yaml \
+  --output data-releases/releases/NEXT
+```
+
+1. Build and publish the code/toolchain-only release-tool image, resolve its
+   immutable digest, and exclude release manifests and plans from its contents.
+2. Create a new release directory from the currently active release and record
+   that resolved materializer digest.
+3. Resolve configured upstream batches and standalone sources.
+4. Download sources into temporary files, never directly over a trusted cache
+   entry.
+5. Validate transport status, file size, checksum, parseability, schemas, CRS,
+   and basic geometry validity.
+6. Apply deterministic enrichment and conversion steps.
+7. Produce exact batch and RHESSys indexes.
+8. Publish output artifacts to durable storage under immutable keys.
+9. Re-download or otherwise verify the published bytes and hashes.
+10. Generate a base-specific forward plan against the expected active release
+   and its exact inverse rollback plan, showing:
+   - datasets and run IDs added, removed, replaced, or retained;
+   - metadata-only, geometry, child, and capability changes;
+   - expected row-count deltas;
+   - enrichment match and conflict reports; and
+   - safety-threshold evaluation.
+11. Commit the manifest and indexes plus the separately keyed plans for review.
+
+Preparation may be rerun, but a published release ID is immutable. Any changed
+target artifact requires a new release ID. A newly encountered base state
+requires a new separately reviewed plan, not a mutation of the target release.
+
+## 13. CI workflow
+
+A data-release pull request should run:
+
+1. manifest and index JSON Schema validation;
+2. checksum and artifact-metadata verification;
+3. deterministic transformation tests;
+4. clean database creation with pinned PostgreSQL/PostGIS and GDAL versions;
+5. Django migrations;
+6. full watershed build from the proposed release;
+7. database validation and API smoke tests;
+8. a second application of the same release, which must report zero watershed
+   changes;
+9. watershed-domain fingerprint comparison before and after the second
+   application, excluding audit-attempt timestamps;
+10. upgrade testing from the currently active release; and
+11. rollback-plan validation where schema compatibility permits.
+
+Authenticated production artifacts may require a protected CI environment or a
+deployment-time preflight. Lack of credentials must not convert required checks
+into warnings.
+
+## 14. Deployment workflow
+
+Data deployment should initially be a protected, manually approved workflow
+separate from ordinary application deployment. The workflow may later be
+composed with application deployment after compatibility rules are proven.
+
+The single operator-facing entry point is proposed as:
+
+```bash
+scripts/deploy_database.sh \
+  --release data-releases/releases/2026-07-16.1/release.yaml \
+  --plan data-releases/plans/BASE--TARGET/MATERIALIZER/forward.json \
+  --expected-base BASE_MANIFEST_SHA
+```
+
+The wrapper is one long-lived host process holding the shared deployment lock.
+It creates a durable database attempt/lease and passes the attempt ID and lease
+token to each phase. Supporting commands remain available for preparation and
+diagnosis, but they do not independently authorize production mutation:
+
+```bash
+python manage.py data_release plan RELEASE
+python manage.py data_release fetch RELEASE
+python manage.py data_release validate RELEASE
+python manage.py data_release apply RELEASE \
+  --attempt ATTEMPT_ID \
+  --expected-base BASE_MANIFEST_SHA \
+  --expected-plan-sha PLAN_SHA256
+python manage.py data_release verify RELEASE
+python manage.py data_release status
+python manage.py data_release recover
+```
+
+The attempt lease is heartbeated during long phases and has an expiry. It
+prevents a second conforming deploy from taking ownership after a process
+crash. It is not a substitute for activation-time database locking and base
+assertions.
+
+Tooling responsibilities should remain separated:
+
+- a tested Python package owns manifest parsing, hashing, transformations,
+  staging, reconciliation, and validation;
+- the Django management command exposes that package with database and settings
+  integration;
+- the shell script owns host checks, Docker invocation, locking, backup
+  orchestration, and durable log/report paths; and
+- the GitHub workflow owns CI, protected-environment approval, secret delivery,
+  and publishing summaries.
+
+Business rules must not be duplicated in shell or workflow YAML.
+
+Production commands run in a one-off, code/toolchain-only release-tool image
+built from the repository root and pinned by image digest. Release manifests
+and plans are deliberately excluded from the image so they can reference its
+already resolved digest without a self-referential build. Deployment mounts the
+exact reviewed files read-only or fetches them by verified hash. The tool image
+connects to the Compose network and mounts only those release files, the
+content-addressed cache, staging/report paths, and required secrets. Deployment
+must not depend on files being present in the long-running server container,
+whose current build context contains only the `server` directory.
+
+The deployment sequence is:
+
+1. Acquire the shared host deployment lock and verify the canonical checkout,
+   Compose project, target environment, immutable tool-image digest, release
+   and plan hashes, schema compatibility, free disk, and database health.
+2. Create the deployment-attempt lease and assert the expected active base
+   release.
+3. Produce a fresh base-specific plan and require it to match the reviewed
+   forward plan exactly.
+4. Fetch all artifacts into the content-addressed cache.
+5. Parse and stage the complete release without modifying serving rows.
+6. Run all pre-activation validations and count comparisons.
+7. Run and verify a production backup, including its required off-host copy,
+   immediately before activation.
+8. In one database transaction:
+   - acquire a transaction-scoped PostgreSQL advisory lock;
+   - lock the singleton `ActiveDataRelease` row with `SELECT ... FOR UPDATE`;
+   - reassert the exact base manifest—or the explicit `EMPTY` state for a first
+     activation—plus schema and materializer digest;
+   - recompute the actual plan from staged and serving rows and compare its
+     hash with the reviewed plan;
+   - update the release-attempt record to `applying`;
+   - upsert changed watershed rows;
+   - reconcile changed child rows by stable business identity;
+   - replace capability serving rows from the staged declarations;
+   - delete explicitly expected obsolete runs;
+   - regenerate simplified geometries where inputs changed;
+   - record actual counts and fingerprints;
+   - run final database invariants before commit; and
+   - mark the new release active and the previous one superseded.
+9. Run post-commit read checks and API smoke tests.
+10. Invalidate application discovery caches or restart the affected workers.
+11. Publish the deployment report and release identity.
+
+If the requested release is already active and its fresh plan contains no
+watershed-domain changes, deployment should record a successful no-op, run the
+verification checks, and exit without taking another backup or rewriting rows.
+
+The application may continue serving the previous committed data during
+staging. The activation transaction should be kept short by doing parsing,
+geometry normalization, and bulk staging beforehand.
+
+### 14.1 Deployment serialization
+
+Application, schema, and data deployments must share:
+
+- one GitHub Actions concurrency group for production;
+- one canonical host lock file;
+- one canonical checkout and explicit Compose project name; and
+- the same compatibility checks against the active data contract.
+
+Application deployment should run migrations as an explicit one-shot step
+before replacing workers and should deploy immutable image digests. It must not
+rely solely on the server entrypoint's automatic `migrate`. Data deployment
+rechecks the running schema and materializer digest immediately before
+activation.
+
+Once the reconciler is enabled, the legacy `load_watershed_data` mutation path
+must be disabled in production or require an explicit recovery-only gate. It
+cannot bypass the deployment lease and active-release assertion.
+
+### 14.2 Safety rails for removals
+
+The apply command must refuse unreviewed destructive changes. At minimum:
+
+- every removal must be represented by an exact run ID in the reviewed plan or
+  a hashed exact set derived from one identified base collection;
+- actual removals must equal the reviewed plan;
+- absolute and percentage removal thresholds must be enforced;
+- an empty desired inventory is invalid unless an explicit disaster-recovery
+  override is supplied;
+- source fetch failure cannot be interpreted as an empty dataset; and
+- `--runids` must never combine with a global delete behavior.
+
+Globs and prefix matching are prohibited as destructive authorization.
+
+### 14.3 Changed-run reconciliation
+
+Fingerprints allow unchanged runs to remain untouched. For a changed run:
+
+- metadata-only change: update authoritative watershed fields;
+- watershed geometry change: update geometry and simplified geometry;
+- child change: update retained business identities in place so public API IDs
+  remain stable, insert additions, and delete only true removals;
+- Parquet change: clear and reapply all fields authoritative to that Parquet
+  schema; and
+- removal: delete the watershed and cascade only after validation confirms it
+  is expected.
+
+This makes repeated deployment efficient without weakening clean-build
+reproducibility.
+
+Current subcatchment and channel auto-primary keys are exposed as GeoJSON
+feature IDs. Reconciliation must therefore preserve those primary keys for
+retained business identities, or a backward-compatible API migration to stable
+composite feature IDs must precede the reconciler.
+
+### 14.4 Staging representation
+
+Version 1 uses fixed, logged, attempt-scoped staging tables created by Django
+migrations. Deployment performs no activation-time DDL. Proposed tables mirror
+the serving watershed, subcatchment, channel, and capability contracts and
+include `attempt_id`, source fingerprint, validation state, and canonical
+business keys.
+
+The staging implementation must:
+
+- bulk load with `COPY` or equivalent bounded-memory operations;
+- enforce uniqueness and type constraints before activation;
+- retain enough normalized source data to recompute the reviewed plan inside
+  the activation transaction;
+- preflight space for artifacts, staging tables, indexes, WAL growth, and the
+  verified backup with an explicit margin;
+- heartbeat the owning attempt while staging;
+- survive a release-tool process crash for diagnosis and safe retry; and
+- let `data_release recover` terminalize expired attempts and remove their
+  staging rows after the retention window.
+
+Logged staging is the default because it survives database restart and makes
+failure recovery explicit. A later unlogged or shadow-schema design requires a
+separate durability and cutover review.
+
+## 15. Application and schema deployment coordination
+
+Code, schema, and data releases have different lifecycles but must declare
+compatibility.
+
+Recommended order for an additive change:
+
+1. deploy backward-compatible schema migration;
+2. deploy application code that can read both old and new data contracts;
+3. deploy the new data release; and
+4. remove old compatibility code in a later application release.
+
+Breaking changes should follow expand-and-contract migrations. A data release
+must declare its contract version, and the apply command must refuse to run
+against incompatible code or migrations.
+
+Compatibility is an executable check, not only an audit field. The release and
+plan lock:
+
+- an exact schema signature or bounded supported migration range;
+- supported data-contract range;
+- release-tool image digest and Git commit;
+- fingerprint-algorithm version; and
+- transformation, GDAL, PostgreSQL, and PostGIS versions that affect output.
+
+Both code and data deploys verify these values before mutation or worker
+replacement.
+
+The production entrypoint may retain `migrate` as a safety check, but the
+deployment workflow should make migration execution and results explicit
+before starting incompatible application workers.
+
+## 16. Rollback and recovery
+
+### 16.1 Failed before activation
+
+No serving rows have changed. Record a failed release attempt, retain diagnostic
+reports, release locks, and temporary artifacts according to retention policy,
+then release the deployment lock.
+
+An attempt abandoned in `planning` or `staging` remains non-authoritative. Its
+heartbeat lease eventually expires, after which `data_release recover` marks it
+failed in a separate transaction and cleans its staging rows according to the
+diagnostic retention policy.
+
+### 16.2 Failed during activation
+
+The transaction rolls back, leaving the previous data release active. Any
+staging objects are retained or marked for cleanup. Because the attempt-status
+update inside the domain transaction also rolls back, the exception handler
+marks the attempt failed in a separate transaction. The singleton active
+release pointer must still reference exactly one previously active release.
+
+### 16.3 Failed after activation
+
+If database invariants pass but application smoke tests fail, run a dedicated
+rollback command using the precomputed exact inverse plan. The rollback command
+asserts that the failed target is still active, uses retained immutable
+artifacts, and applies the same locks and validation rules as a forward deploy.
+If persistent state or schema is damaged, enter maintenance mode and restore the
+verified backup.
+
+The deployment report must distinguish rollback by reconciliation from restore
+from backup. Backup restorability should be tested periodically on a separate
+database; archive creation alone is not a restore test. Full restore is a
+disaster operation because it also rolls back unrelated authentication,
+session, admin, and other writes made after the backup.
+
+### 16.4 Disaster rebuild
+
+Given an empty named volume or new PostgreSQL instance:
+
+1. initialize the database and roles;
+2. run all Django migrations;
+3. seed explicitly required operational accounts from protected configuration;
+4. apply the selected data release;
+5. verify database and API invariants; and
+6. activate the application.
+
+Silk request history, sessions, and other explicitly nonessential operational
+records are not part of the data release.
+
+## 17. Validation contract
+
+Validation occurs at artifact, run, release, and application levels.
+
+### 17.1 Artifact validation
+
+- checksum and byte size;
+- expected media type and parseability;
+- required fields and data types;
+- no unexpected duplicate identity keys;
+- CRS and geometry type;
+- GeoTIFF and Parquet structural metadata; and
+- no credential or HTML error page saved as a data artifact.
+
+### 17.2 Run validation
+
+- exactly one watershed row;
+- expected metadata completeness;
+- valid, nonempty geometry in EPSG:4326;
+- reasonable bounds and area change from the previous release;
+- expected subcatchment and channel counts;
+- unique child identities;
+- no orphan children;
+- every Parquet `topazid` has exactly one expected subcatchment, with no
+  duplicate Parquet identity; and
+- declared RHESSys products pass structural and sample-read checks.
+
+### 17.3 Release validation
+
+- exact desired run ID set;
+- exact expected addition and removal set;
+- aggregate counts and count deltas within reviewed thresholds;
+- all required dataset entries succeeded;
+- no unexpired competing attempt exists and every expired attempt in
+  `planning`, `staging`, or `applying` has a recoverable terminalization path;
+- exactly one `ActiveDataRelease` singleton exists; it may be `EMPTY` only
+  before first activation, and every accepted populated release requires
+  `ACTIVE` with a non-null pointer;
+- manifest and plan hashes match the reviewed release; and
+- database fingerprints match the expected clean-build fingerprints for the
+  same inputs.
+
+### 17.4 Application smoke tests
+
+- health and database connectivity;
+- watershed list and detail endpoints;
+- representative geometry, subcatchment, and channel endpoints;
+- SBS endpoint for a run that declares SBS data;
+- RHESSys catalog and one representative tile or query for each capability
+  mode; and
+- known removed run returns not found.
+
+## 18. Observability and audit
+
+Every attempt should emit structured logs and a machine-readable report with:
+
+- release, manifest, plan, code, and workflow identities;
+- operator and target environment;
+- previous and resulting active release;
+- artifact fetch/cache results without credentials;
+- per-run action and input fingerprints;
+- expected and actual counts;
+- duration by phase;
+- validation results;
+- backup artifact identity;
+- activation or rollback outcome; and
+- cache cleanup recommendations.
+
+The active release ID should be exposed through an authenticated status command
+and optionally an application health/status endpoint.
+
+## 19. Storage and retention
+
+### 19.1 PostgreSQL
+
+- pin the currently running Postgres/PostGIS image by digest before changing
+  storage, without combining the storage cutover with a database upgrade;
+- migrate the live anonymous volume to a named `postgres_data` volume using the
+  one-time cutover runbook below;
+- never use `docker compose down -v` in ordinary deployment;
+- monitor free space and table growth; and
+- set a retention policy for Silk, especially response bodies, so operational
+  tracing does not dominate database size.
+
+Adding the Compose mount directly would create an empty database. The one-time
+cutover must therefore:
+
+1. identify one canonical production checkout and Compose project and correct
+   systemd to use `compose.prod.yml` explicitly;
+2. create and verify an encrypted off-host logical backup;
+3. enter maintenance mode and quiesce database writes;
+4. provision the named volume with the pinned current image;
+5. restore the logical backup, or use a separately reviewed physical-copy
+   procedure compatible with the exact database version;
+6. verify roles, extensions, migrations, release state, table counts,
+   fingerprints, and application smoke tests;
+7. switch Compose and systemd to the named volume; and
+8. retain the stopped anonymous volume until the cutover is accepted and the
+   rollback window closes.
+
+### 19.2 Data artifacts
+
+- use off-host, project-controlled S3-compatible storage with encryption,
+  versioning or object lock, content-addressed keys, and no TTL for retained
+  releases;
+- keep artifacts for the active release and at least two rollback releases;
+- use content-addressed keys so identical artifacts are shared safely;
+- garbage-collect only blobs unreferenced by retained manifests;
+- record licensing or sensitivity constraints where relevant; and
+- ensure TTL policies cannot remove accepted release artifacts.
+
+### 19.3 Local cache
+
+- verify content on every cache hit;
+- download to a temporary file and atomically rename after verification;
+- do not modify a content-addressed cache entry;
+- allow safe concurrent readers; and
+- clean unreferenced entries only outside an active build.
+
+### 19.4 Backups
+
+- every destructive deployment and storage cutover requires a newly verified,
+  encrypted off-host backup before activation;
+- retain backups for the active release and at least two rollback releases;
+- run scheduled encrypted off-host backups now with a default maximum
+  recovery-point objective of 24 hours until a stricter product requirement is
+  defined;
+- test restore into an isolated database on a schedule and before relying on a
+  new backup or database-image format; and
+- document maintenance-mode entry, restore, verification, and exit procedures.
+
+## 20. Security
+
+- keep JWTs and database credentials in protected deployment secrets;
+- avoid credentials in URLs, process listings, plans, and logs;
+- remove the production PostgreSQL host port unless it is required, or bind it
+  only to `127.0.0.1` while application containers use the Compose network;
+- create any temporary environment file with mode `0600`, minimize its
+  contents, and guarantee cleanup on success, failure, and cancellation;
+- use least-privilege database roles for planning, staging, and applying where
+  practical;
+- restrict production data deployment through an approved environment;
+- treat backups and database-global dumps as sensitive;
+- verify artifact transport and content hashes; and
+- record who approved and applied each release.
+
+## 21. Proposed implementation phases
+
+### Phase 0: production safety
+
+- pin the currently running PostGIS image without upgrading it;
+- execute the backed-up, quiesced, verified cutover from the anonymous volume
+  to a named PostgreSQL volume;
+- select one canonical checkout and Compose project and correct systemd to use
+  `compose.prod.yml`;
+- serialize current code deployments with a shared host lock;
+- remove or loopback-bind the PostgreSQL host port and protect temporary
+  environment files with mode `0600`;
+- correct deployment documentation and systemd Compose-file usage;
+- establish Silk retention or disable unnecessary response capture;
+- establish scheduled encrypted off-host backups with a 24-hour default RPO,
+  retention, and periodic restore tests;
+- prohibit `load_watershed_data --force` in production, especially the
+  globally destructive `--force --runids` combination.
+
+### Phase 1: release representation
+
+- define release, batch-index, and RHESSys-index schemas;
+- create the first manifest from the authoritative inventory;
+- require distinct immutable collection and watershed keys;
+- define field-by-field metadata authority and exact child business keys;
+- implement content-addressed artifact storage and cache layout; and
+- generate separately keyed forward, rollback, and empty-build plans.
+
+### Phase 2: strict clean builder
+
+- make required source failures fatal;
+- implement deterministic preparation and NASA enrichment;
+- build into an empty CI database;
+- add integrity constraints and validation commands; and
+- prove that two independent empty builds produce identical watershed-domain
+  fingerprints.
+
+### Phase 3: transactional reconciler
+
+- add the release, active-pointer, attempt-lease, and per-run state models;
+- implement logged attempt-scoped staging and recovery;
+- implement metadata and child upserts that preserve retained public IDs,
+  capability serving rows, and exact expected deletion;
+- add transaction locking, expected-base assertions, and removal safety rails;
+- prove that applying an active release again makes zero domain changes; and
+- preserve non-watershed Django state.
+
+### Phase 4: deployment integration
+
+- implement `scripts/deploy_database.sh`;
+- build a one-off release-tool image from the repository root and pin it by
+  digest;
+- add protected code/data workflows with one shared production concurrency
+  group and explicit one-shot migrations;
+- integrate verified off-host backup, base-specific plan approval, smoke tests,
+  reports, and exact inverse rollback;
+- expose active release status; and
+- update the inventory snapshot automatically or from the deployment report.
+
+### Phase 5: optional blue-green data deployment
+
+- measure staging and activation time;
+- evaluate a second database or versioned-schema cutover if in-place activation
+  becomes too slow;
+- separate persistent application state if full-database replacement is
+  adopted; and
+- retain the same release manifest and validation contracts.
+
+## 22. Acceptance criteria for the first production-capable version
+
+The tooling is ready to replace the current manual loader workflow when it can
+demonstrate all of the following:
+
+1. Build the accepted inventory from an empty database.
+2. Apply the same release twice with a zero-change second plan.
+3. Remove one reviewed watershed without affecting unrelated runs.
+4. Apply a metadata-only change without rebuilding unchanged child rows.
+5. Add a batch and validate its exact locked membership.
+6. Replace the NASA batch using a deterministic, audited enrichment artifact.
+7. Replace Mill Creek and validate its re-vendored RHESSys capability.
+8. Abort a release with one missing required source while leaving production
+   unchanged.
+9. Reject an unexpected large removal or empty upstream result.
+10. Roll back to the previous compatible data release.
+11. Reconstruct the active watershed data after loss of the PostgreSQL volume.
+12. Produce a report sufficient to identify every input and code revision used.
+13. Preserve retained watershed, subcatchment, and channel public identities.
+14. Reject a plan whose active base, schema signature, or materializer digest
+    differs from the reviewed values.
+15. Prevent code/schema deployment and data activation from running
+    concurrently.
+
+## 23. Recommended defaults and remaining decisions
+
+The architecture adopts these defaults unless an implementation proposal
+documents and approves a replacement:
+
+1. Accepted artifacts use off-host, project-controlled S3-compatible storage
+   with encryption, object versioning or lock, content-addressed keys, and no
+   TTL while referenced by a retained release.
+2. Every non-watershed Django table is persistent by default. Only explicitly
+   declared watershed-domain and capability tables are reconciled; Silk has a
+   separate expiry policy.
+3. Every watershed receives a mandatory immutable `watershed_key` now. `runid`
+   remains a replaceable source revision and compatibility alias.
+4. The reviewed hashed member index is authoritative. Intentional exclusions
+   require pull-request review, and destructive authorization always resolves
+   to exact run IDs.
+5. Metadata authority is defined field by field. Successor run IDs and
+   geometries are target-authoritative; unresolved conflicts fail preparation.
+6. Accepted RHESSys assets move to the durable project-controlled namespace and
+   are served through atomically materialized capability configuration.
+7. Merging a release pull request does not deploy it. Production application
+   requires a protected manual action and a reviewer distinct from the release
+   preparer.
+8. Retain at least the active release plus two rollback releases, including
+   their artifacts, plans, reports, and verified off-host backups.
+9. The complete release-tool image, pinned by digest, is the reproducibility
+   contract for Python, GDAL, transformation libraries, and client tools.
+
+The remaining project-specific decisions are:
+
+1. Which S3-compatible provider, bucket ownership, encryption keys, and access
+   roles will implement the artifact-store default?
+2. What naming scheme assigns watershed keys to existing batch members, and
+   when do public routes migrate from run IDs with compatibility redirects?
+3. What is the complete field-level metadata precedence matrix for each
+   collection?
+4. What activation lock-time and API-latency budget triggers blue-green
+   deployment?
+5. Does persistent application state require an RPO shorter than the proposed
+   24-hour default?
+6. Which people or teams may prepare, independently approve, deploy, and roll
+   back a release?
+
+Until these are resolved, release preparation and planning can be implemented
+without authorizing automatic production mutation.

--- a/docs/database-inventory.md
+++ b/docs/database-inventory.md
@@ -1,0 +1,201 @@
+# Production Database and Data-Source Inventory
+
+This document is the authoritative inventory of watershed datasets intended
+for the production Utility Watershed Analytics deployment. It records both the
+observed production state and the approved target state so an incomplete data
+migration is not mistaken for the desired configuration.
+
+The proposed representation and deployment process for this inventory is
+specified in
+[Database Deployment Architecture and Tooling](database-deployment-architecture.md).
+
+Last updated: 2026-07-16
+
+## Scope and authority
+
+The PostgreSQL/PostGIS database stores watershed, subcatchment, channel, soil,
+land-use, and related attributes loaded by the Django watershed loader.
+RHESSys rasters, GeoJSON, and Parquet outputs are not stored in PostgreSQL;
+the current application reads or proxies them from the corresponding WEPPcloud
+run. The approved deployment target requires accepted RHESSys assets to be
+copied into project-controlled, no-TTL storage and exposed through materialized
+capability configuration. Consequently, a watershed row in PostgreSQL does not
+prove that its RHESSys assets are available or release-ready.
+
+Update this document in the same pull request as any change to an accepted
+batch, standalone run ID, master GeoJSON, or RHESSys asset location. After a
+production data operation, update the observed snapshot and verification date.
+Run IDs in this document are case-sensitive.
+
+Lifecycle terms:
+
+- **Retain**: accepted and expected to remain in production.
+- **Add**: accepted but not yet present in the verified production snapshot.
+- **Replace**: accepted successor to a dataset that will be retired.
+- **Retire**: may still be present temporarily, but is not part of the target
+  inventory.
+
+## Approved inventory
+
+| Dataset | Canonical run ID or prefix | Lifecycle | Production database | RHESSys assets | Required action |
+| --- | --- | --- | --- | --- | --- |
+| Gate Creek | `aversive-forestry` | Retain | Present | Observed in WEPPcloud: spatial inputs plus dynamic scenario Parquets for `S1`, `S2`, and `S4b` | Retain the database row; copy, index, and verify the RHESSys assets in durable project storage. |
+| Mill Creek | `some-oligopoly` | Replace | Not present as of 2026-07-16 | Must be re-vendored to durable project storage | Configure and load the new standalone run, publish the required RHESSys assets durably, verify them, and then retire the former run. |
+| Former Mill Creek | `mdobre-invincible-scarab` | Retire | Present as of 2026-07-16 | Unavailable; the run is believed to have been removed by the deletion TTL | Remove from the database only after `some-oligopoly` is loaded and validated. Do not treat this run as a recoverable source. |
+| Victoria, BC | `batch;;victoria-ca-2026-sbs;;<member>` | Retain | Present; 31 members | WEPPcloud output maps are confirmed for `Sooke09` and `Sooke15` only | Retain the batch; copy and verify those assets in durable project storage. Do not infer RHESSys availability for other members. |
+| NASA ROSES, current | `batch;;nasa-roses-2026-sbs;;<member>` | Retire | Present; 93 members | None recorded | Replace with the 202606 PSBS batch after enrichment and load validation. |
+| NASA ROSES, successor | `batch;;nasa-roses-202606-psbs;;<member>` | Replace | Not present as of 2026-07-16 | None recorded | Enrich its resources GeoJSON as specified below, configure the loader, load it, validate it, and then retire the old NASA batch. |
+| Bremerton | `batch;;bremerton-2026-psbs;;<member>` | Add | Not present as of 2026-07-16 | None recorded | Add the batch to loader configuration and load it after validating its resources GeoJSON and per-run products. |
+
+The full Victoria batch identifier is
+`batch;;victoria-ca-2026-sbs;;<member>`. Shortened forms such as
+`batch;;victoria-ca-2026` are descriptive only and must not be stored as run
+IDs.
+
+## RHESSys inventory
+
+RHESSys capability is associated with the external run, not a database column.
+The authoritative RHESSys-enabled run list is therefore:
+
+| Run ID | Watershed | Supported product form | Status verified 2026-07-16 |
+| --- | --- | --- | --- |
+| `aversive-forestry` | Gate Creek | Spatial-input GeoTIFFs; scenario, basin, hillslope, and patch Parquets used for dynamic maps and time series | Observed available in WEPPcloud. Durable copy and capability activation remain pending. The precomputed `rhessys/maps/` directory is not required. |
+| `some-oligopoly` | Mill Creek | Precomputed RHESSys output GeoTIFFs under `rhessys/maps/` | Pending durable re-vendoring and verification. |
+| `batch;;victoria-ca-2026-sbs;;Sooke09` | Sooke09 | Precomputed RHESSys output GeoTIFFs under `rhessys/maps/` | Observed available in WEPPcloud, including baseline, fire/thinning change, and one-year difference products. Durable copy remains pending. |
+| `batch;;victoria-ca-2026-sbs;;Sooke15` | Sooke15 | Precomputed RHESSys output GeoTIFFs under `rhessys/maps/` | Observed available in WEPPcloud, including baseline and fire/thinning change products. Durable copy remains pending. |
+
+No other production run should be described as RHESSys-enabled without adding
+it to this table after its required external assets have been verified.
+No declared capability is ready for release activation until its immutable
+asset index and project-controlled durable copy have also been verified.
+
+### Mill Creek re-vendoring acceptance criteria
+
+Before switching the application from `mdobre-invincible-scarab` to
+`some-oligopoly`:
+
+1. Establish and record the new run's actual project directory (for example,
+   `disturbed9002` versus `disturbed9002_wbt`) in the standalone loader
+   configuration.
+2. Load and validate its boundary, subcatchments, channels, hillslope, soil,
+   and land-use products.
+3. Publish the precomputed RHESSys map scenario directories and registered
+   GeoTIFF variables expected by the application under `rhessys/maps/` in
+   project-controlled, no-TTL storage with an immutable asset index.
+4. Verify the RHESSys catalog endpoint returns at least one scenario and that a
+   tile from every published variable can be rendered.
+5. Update application references and development run lists from
+   `mdobre-invincible-scarab` to `some-oligopoly`.
+6. Remove the former database row only after the new watershed and RHESSys
+   views pass validation.
+
+## NASA 202606 resources enrichment contract
+
+The target master resource is the resources GeoJSON belonging to
+`batch;;nasa-roses-202606-psbs`. Its target run IDs and geometries must remain
+authoritative. Enrich it with watershed attributes from:
+
+<https://bucket.bearhive.duckdns.org/WWS_Watersheds_HUC10_Merged.geojson>
+
+Source observed on 2026-07-16:
+
+- 395 GeoJSON features
+- 8,935,440 bytes
+- `Last-Modified: Wed, 10 Dec 2025 17:39:31 GMT`
+- SHA-256:
+  `be152890a8436d931f962b6eabe32287935d8da5303c5f532985ec835e8954ce`
+- `WWS_Code` is present and unique across all 395 features.
+- `PWS_ID` is present but is not unique: there are 283 distinct values, so it
+  is not a safe join key by itself.
+
+Copy these source properties when matches are established:
+
+- `PWS_ID`
+- `SrcName`
+- `PWS_Name`
+- `County_Nam`
+- `State`
+- `HUC10_ID`
+- `HUC10_Name`
+- `WWS_Code`
+- `SrcType`
+- `Shape_Leng`
+- `Shape_Area`
+- `outlet_lon_lat`
+
+Do not copy the source `runid`: the enrichment file contains historical
+`batch;;nasa-roses-2025;;<member>` identifiers. Do not replace the target
+geometry. `WWS_Code` is the candidate join key, but the merge must first prove
+that it is present and unique in the target resource. Produce an unmatched and
+duplicate-key report rather than silently dropping or multiplying features.
+
+The enrichment source does **not** contain the current Django utility metadata
+properties `OwnerType`, `PopGroup`, `TreatType`, `ConnGroup`, or the
+`HUC10_*` utility aggregates. If those fields must remain populated in the
+successor batch, they require a separate, identified source. Also note that
+`outlet_lon_lat` is not currently represented by a Django model field and will
+remain only in the GeoJSON unless the database schema is extended.
+
+The enriched resource is accepted only when:
+
+1. its feature count and geometry values match the unmodified target resource;
+2. every feature has a non-null, unique `runid` beginning with
+   `batch;;nasa-roses-202606-psbs;;`;
+3. join-key uniqueness, matched, unmatched, and duplicate counts are recorded;
+4. no historical source `runid` has been copied into the output;
+5. `data_release validate` and an isolated staging build preserve the expected
+   watershed, subcatchment, and channel relationships; the current loader's
+   `--dry-run` output is not sufficient validation; and
+6. the observed production snapshot below is updated after the final load.
+
+## Observed production snapshot
+
+Read-only inspection of `wepp3` on 2026-07-16 found:
+
+| Stored source | Watersheds | `owner_type` populated | `huc10_utility_count` populated |
+| --- | ---: | ---: | ---: |
+| `nasa-roses-2026-sbs` | 93 | 85 | 92 |
+| `victoria-ca-2026-sbs` | 31 | 0 | 0 |
+| `aversive-forestry` | 1 | 0 | 0 |
+| `mdobre-invincible-scarab` | 1 | 0 | 0 |
+| **Total** | **126** | **85** | **92** |
+
+Associated-table totals were 195,457 subcatchments and 86,895 channels. This
+snapshot describes what is stored, not the approved target inventory. In
+particular, the old NASA and Mill Creek records remain present while their
+successors are pending.
+
+Use this read-only query to refresh the grouped snapshot:
+
+```sql
+SELECT
+    CASE
+        WHEN runid LIKE 'batch;;%'
+            THEN split_part(runid, ';;', 2)
+        ELSE 'standalone:' || runid
+    END AS source,
+    count(*) AS watersheds,
+    count(owner_type) AS owner_type_present,
+    count(huc10_utility_count) AS huc10_aggregates_present
+FROM watershed_watershed
+GROUP BY 1
+ORDER BY 1;
+```
+
+## Loader and database boundaries
+
+The observed production inventory is currently loaded through the batch and
+standalone configuration in `server/server/watershed/loaders/config.py`. The
+approved target inventory above is not yet fully represented there: the NASA
+successor, new Mill Creek run, and Bremerton batch remain pending. The current
+loader materializes three geometry-bearing tables:
+
+- `watershed_watershed`: one row per canonical run ID;
+- `watershed_subcatchment`: subcatchments linked to a watershed by foreign key;
+- `watershed_channel`: channels linked to a watershed by foreign key.
+
+RHESSys discovery currently probes WEPPcloud on demand and caches discovery
+results in application memory for one hour. It does not persist availability
+in PostgreSQL. A database backup therefore protects the loaded watershed
+tables but does not protect the external RHESSys assets or master GeoJSON
+resources; those must be retained separately.

--- a/scripts/backup_database.sh
+++ b/scripts/backup_database.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+umask 077
+
+readonly DEFAULT_CONTAINER="postgis"
+readonly DEFAULT_OUTPUT_DIR="/workdir/backups/utility-watershed-analytics"
+readonly DEFAULT_SPACE_MARGIN_BYTES=$((5 * 1024 * 1024 * 1024))
+readonly DEFAULT_LOCK_WAIT_TIMEOUT="60s"
+
+container="${POSTGRES_CONTAINER:-$DEFAULT_CONTAINER}"
+output_dir="${BACKUP_OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
+space_margin_bytes="${BACKUP_SPACE_MARGIN_BYTES:-$DEFAULT_SPACE_MARGIN_BYTES}"
+lock_wait_timeout="${BACKUP_LOCK_WAIT_TIMEOUT:-$DEFAULT_LOCK_WAIT_TIMEOUT}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Create and verify a custom-format backup of the PostgreSQL database running
+in the production PostGIS container. The archive is streamed directly to the
+host, so it is not stored in the container or its anonymous data volume.
+
+Options:
+  --container NAME    PostgreSQL container name (default: $DEFAULT_CONTAINER)
+  --output-dir PATH   Host backup directory (default: $DEFAULT_OUTPUT_DIR)
+  -h, --help          Show this help
+
+Environment overrides:
+  POSTGRES_CONTAINER          Same as --container
+  BACKUP_OUTPUT_DIR           Same as --output-dir
+  BACKUP_SPACE_MARGIN_BYTES   Free-space margin beyond pg_database_size
+  BACKUP_LOCK_WAIT_TIMEOUT    Maximum wait for a pg_dump table lock (default: 60s)
+  BACKUP_LOCK_FILE            Host-wide advisory lock file
+
+The script never deletes previous backups.
+The globals file can contain role password verifiers; treat every artifact as sensitive.
+EOF
+}
+
+log() {
+    printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$1" "$2"
+}
+
+die() {
+    log ERROR "$1" >&2
+    exit 1
+}
+
+while (($# > 0)); do
+    case "$1" in
+        --container)
+            (($# >= 2)) || die "--container requires a value"
+            container="$2"
+            shift 2
+            ;;
+        --output-dir)
+            (($# >= 2)) || die "--output-dir requires a value"
+            output_dir="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "Unknown option: $1"
+            ;;
+    esac
+done
+
+for command in awk basename date df docker flock grep hostname id install \
+    mv sha256sum sync tee tr wc; do
+    command -v "$command" >/dev/null 2>&1 || die "Required command not found: $command"
+done
+
+[[ "$space_margin_bytes" =~ ^[0-9]+$ ]] \
+    || die "BACKUP_SPACE_MARGIN_BYTES must be a non-negative integer"
+[[ "$lock_wait_timeout" =~ ^[0-9]+(ms|s|min|h)?$ ]] \
+    || die "BACKUP_LOCK_WAIT_TIMEOUT must be a PostgreSQL duration such as 60s"
+
+runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+[[ -d "$runtime_dir" && -w "$runtime_dir" ]] \
+    || die "User runtime directory is unavailable: $runtime_dir"
+lock_file="${BACKUP_LOCK_FILE:-$runtime_dir/utility-watershed-analytics-db-backup.lock}"
+exec 9>"$lock_file"
+flock -n 9 || die "Another database backup is already running (lock: $lock_file)"
+
+if [[ ! -d "$output_dir" ]]; then
+    install -d -m 700 -- "$output_dir"
+fi
+[[ -w "$output_dir" ]] || die "Backup directory is not writable: $output_dir"
+
+timestamp="$(date -u +'%Y%m%dT%H%M%SZ')"
+log_file="$output_dir/database-backup-$timestamp.log"
+exec > >(tee -a "$log_file") 2>&1
+
+docker inspect "$container" >/dev/null 2>&1 \
+    || die "PostgreSQL container not found: $container"
+[[ "$(docker inspect --format '{{.State.Running}}' "$container")" == "true" ]] \
+    || die "PostgreSQL container is not running: $container"
+
+docker exec "$container" sh -ceu '
+    command -v pg_dump >/dev/null
+    command -v pg_dumpall >/dev/null
+    command -v pg_restore >/dev/null
+    pg_isready -q --username "${POSTGRES_USER:?}" --dbname "${POSTGRES_DB:?}"
+' || die "PostgreSQL backup tools or database readiness check failed"
+
+database_name="$(
+    docker exec "$container" sh -ceu 'printf "%s" "${POSTGRES_DB:?}"'
+)"
+database_user="$(
+    docker exec "$container" sh -ceu 'printf "%s" "${POSTGRES_USER:?}"'
+)"
+[[ -n "$database_name" ]] || die "POSTGRES_DB is empty in container $container"
+[[ -n "$database_user" ]] || die "POSTGRES_USER is empty in container $container"
+
+safe_database_name="${database_name//[^a-zA-Z0-9_.-]/_}"
+backup_base="${safe_database_name}_${timestamp}"
+archive="$output_dir/$backup_base.dump"
+archive_partial="$archive.partial"
+globals_file="$output_dir/$backup_base.globals.sql"
+globals_partial="$globals_file.partial"
+checksum_file="$archive.sha256"
+checksum_partial="$checksum_file.partial"
+toc_file="$archive.toc.txt"
+toc_partial="$toc_file.partial"
+metadata_file="$archive.metadata.txt"
+metadata_partial="$metadata_file.partial"
+complete_file="$archive.complete"
+complete_partial="$complete_file.partial"
+
+for path in \
+    "$archive" "$archive_partial" \
+    "$globals_file" "$globals_partial" \
+    "$checksum_file" "$checksum_partial" \
+    "$toc_file" "$toc_partial" \
+    "$metadata_file" "$metadata_partial" \
+    "$complete_file" "$complete_partial"; do
+    [[ ! -e "$path" ]] || die "Refusing to overwrite existing path: $path"
+done
+
+completed=0
+on_exit() {
+    local status=$?
+    if ((status != 0 || completed == 0)); then
+        log ERROR "Backup did not complete successfully (exit status $status)"
+        if [[ -e "$archive_partial" ]]; then
+            log ERROR "Incomplete archive retained for diagnosis: $archive_partial"
+        elif [[ -e "$archive" && ! -e "$complete_file" ]]; then
+            log ERROR "Archive exists without a completion marker; do not trust it yet: $archive"
+        fi
+    fi
+}
+trap on_exit EXIT
+
+read_only_psql() {
+    local sql="$1"
+    docker exec "$container" sh -ceu '
+        export PGOPTIONS="-c default_transaction_read_only=on -c statement_timeout=15000"
+        exec psql -X -qAt --no-password -v ON_ERROR_STOP=1 \
+            --username "${POSTGRES_USER:?}" \
+            --dbname "${POSTGRES_DB:?}" \
+            --command "$1"
+    ' sh "$sql"
+}
+
+database_size_bytes="$(read_only_psql 'SELECT pg_database_size(current_database());')"
+[[ "$database_size_bytes" =~ ^[0-9]+$ ]] \
+    || die "Could not determine database size"
+
+available_bytes="$(df -PB1 -- "$output_dir" | awk 'NR == 2 {print $4}')"
+[[ "$available_bytes" =~ ^[0-9]+$ ]] \
+    || die "Could not determine free space for $output_dir"
+
+required_bytes=$((database_size_bytes + space_margin_bytes))
+if ((available_bytes < required_bytes)); then
+    die "Insufficient free space: available=$available_bytes required=$required_bytes"
+fi
+
+server_version="$(read_only_psql 'SHOW server_version;')"
+postgis_version="$(read_only_psql "SELECT extversion FROM pg_extension WHERE extname = 'postgis';")"
+container_image="$(docker inspect --format '{{.Config.Image}}' "$container")"
+container_image_id="$(docker inspect --format '{{.Image}}' "$container")"
+started_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+log INFO "Starting PostgreSQL backup"
+log INFO "Container: $container"
+log INFO "Database: $database_name"
+log INFO "Output archive: $archive"
+log INFO "Database size: $database_size_bytes bytes"
+log INFO "Available space: $available_bytes bytes"
+
+dump_started_seconds=$SECONDS
+if ! docker exec -e BACKUP_LOCK_WAIT_TIMEOUT="$lock_wait_timeout" "$container" sh -ceu '
+    export PGOPTIONS="-c default_transaction_read_only=on"
+    exec pg_dump \
+        --host /var/run/postgresql \
+        --username "${POSTGRES_USER:?}" \
+        --dbname "${POSTGRES_DB:?}" \
+        --format custom \
+        --compress 6 \
+        --lock-wait-timeout "$BACKUP_LOCK_WAIT_TIMEOUT" \
+        --verbose \
+        --no-password
+' >"$archive_partial"; then
+    die "pg_dump failed; the partial archive is not a valid backup"
+fi
+dump_duration_seconds=$((SECONDS - dump_started_seconds))
+
+[[ -s "$archive_partial" ]] || die "pg_dump produced an empty archive"
+
+log INFO "Capturing cluster-global roles, memberships, grants, and tablespaces"
+if ! docker exec "$container" sh -ceu '
+    export PGOPTIONS="-c default_transaction_read_only=on"
+    exec pg_dumpall \
+        --host /var/run/postgresql \
+        --username "${POSTGRES_USER:?}" \
+        --database "${POSTGRES_DB:?}" \
+        --globals-only \
+        --no-password
+' >"$globals_partial"; then
+    die "pg_dumpall --globals-only failed"
+fi
+[[ -s "$globals_partial" ]] || die "pg_dumpall produced an empty globals file"
+
+log INFO "Verifying archive structure with pg_restore --list"
+docker exec -i "$container" pg_restore --list \
+    <"$archive_partial" >"$toc_partial" \
+    || die "pg_restore could not read the generated archive"
+
+for required_table in \
+    watershed_watershed \
+    watershed_subcatchment \
+    watershed_channel \
+    django_migrations; do
+    grep -Eq "TABLE DATA [^ ]+ ${required_table}( |$)" "$toc_partial" \
+        || die "Verified archive is missing table data entry: $required_table"
+done
+
+log INFO "Fully decoding archive payload with pg_restore"
+docker exec -i "$container" pg_restore --file /dev/null \
+    <"$archive_partial" \
+    || die "pg_restore could not fully decode the generated archive"
+
+archive_size_bytes="$(wc -c <"$archive_partial" | tr -d '[:space:]')"
+archive_sha256="$(sha256sum "$archive_partial" | awk '{print $1}')"
+globals_size_bytes="$(wc -c <"$globals_partial" | tr -d '[:space:]')"
+globals_sha256="$(sha256sum "$globals_partial" | awk '{print $1}')"
+completed_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+{
+    printf '%s  %s\n' "$archive_sha256" "$(basename "$archive")"
+    printf '%s  %s\n' "$globals_sha256" "$(basename "$globals_file")"
+} >"$checksum_partial"
+
+{
+    printf 'backup_started_utc=%s\n' "$started_at"
+    printf 'backup_completed_utc=%s\n' "$completed_at"
+    printf 'hostname=%s\n' "$(hostname -f 2>/dev/null || hostname)"
+    printf 'container=%s\n' "$container"
+    printf 'container_image=%s\n' "$container_image"
+    printf 'container_image_id=%s\n' "$container_image_id"
+    printf 'database=%s\n' "$database_name"
+    printf 'database_user=%s\n' "$database_user"
+    printf 'postgres_server_version=%s\n' "$server_version"
+    printf 'postgis_version=%s\n' "$postgis_version"
+    printf 'database_size_bytes_at_start=%s\n' "$database_size_bytes"
+    printf 'archive_size_bytes=%s\n' "$archive_size_bytes"
+    printf 'archive_sha256=%s\n' "$archive_sha256"
+    printf 'globals_size_bytes=%s\n' "$globals_size_bytes"
+    printf 'globals_sha256=%s\n' "$globals_sha256"
+    printf 'dump_duration_seconds=%s\n' "$dump_duration_seconds"
+    printf 'archive_validation=pg_restore_full_decode_to_dev_null\n'
+    printf 'restore_tested=false\n'
+} >"$metadata_partial"
+
+log INFO "Synchronizing backup data to durable host storage"
+sync -- \
+    "$archive_partial" \
+    "$globals_partial" \
+    "$checksum_partial" \
+    "$toc_partial" \
+    "$metadata_partial"
+
+mv -- "$globals_partial" "$globals_file"
+mv -- "$checksum_partial" "$checksum_file"
+mv -- "$toc_partial" "$toc_file"
+mv -- "$metadata_partial" "$metadata_file"
+mv -- "$archive_partial" "$archive"
+
+sync -- \
+    "$archive" \
+    "$globals_file" \
+    "$checksum_file" \
+    "$toc_file" \
+    "$metadata_file" \
+    "$output_dir"
+
+{
+    printf 'completed_utc=%s\n' "$completed_at"
+    printf 'archive=%s\n' "$(basename "$archive")"
+    printf 'checksum=%s\n' "$(basename "$checksum_file")"
+} >"$complete_partial"
+sync -- "$complete_partial"
+mv -- "$complete_partial" "$complete_file"
+sync -- "$complete_file" "$output_dir"
+
+completed=1
+trap - EXIT
+
+log INFO "Backup completed and verified"
+log INFO "Archive size: $archive_size_bytes bytes"
+log INFO "SHA-256: $archive_sha256"
+log INFO "Duration: $dump_duration_seconds seconds"
+log INFO "Archive: $archive"
+log INFO "Globals: $globals_file"
+log INFO "Checksum: $checksum_file"
+log INFO "Metadata: $metadata_file"
+log INFO "Table-of-contents: $toc_file"
+log INFO "Completion marker: $complete_file"
+log INFO "Verify checksums from $output_dir with: sha256sum --check $(basename "$checksum_file")"


### PR DESCRIPTION
## What changed

- add a production PostgreSQL backup script with locking, capacity checks, custom-format dump validation, checksums, metadata, durable publication, and a completion marker
- add the authoritative production database and RHESSys inventory
- add a proposed desired-state database release and deployment architecture
- record independent architecture review findings and their dispositions
- correct deployment documentation that previously recommended destructive reset workflows or overstated loader validation
- keep local systems-administration logs out of Git

## Why

Production PostgreSQL currently uses an anonymous volume, while watershed data comes from mutable upstream batches and TTL-managed runs. The current loader is not an idempotent reconciliation process: forced loading deletes the existing watershed inventory first, source-level failures can be swallowed, and filename-only caching can preserve stale inputs.

This change supplies a verified backup tool and establishes a reviewed design for exact, immutable data releases, strict staging, atomic reconciliation, rollback, stable identity, durable RHESSys assets, and controlled migration to named storage.

## Impact

This PR does not change application runtime behavior or production data automatically. The backup script is operator-invoked. The architecture and inventory documents define proposed future work; the review record distinguishes accepted design requirements from work already implemented.

The globals backup contains role password verifiers and must be handled as sensitive material.

## Validation

- `bash -n scripts/backup_database.sh`
- successful production backup on `wepp3`, including archive listing, full payload decode, checksums, completion marker, and database count checks
- two independent backup-script review passes
- independent architecture review: 18 initial findings plus five closure findings, all dispositioned; final targeted closure found no residual issue
- read-only production audit found no duplicate subcatchment `topazid` identities within a watershed
- `git diff --check`
- Markdown fence-balance checks for changed documentation

`shellcheck` was not available locally.
